### PR TITLE
ci: standardize on one tendermint hash

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -117,7 +117,7 @@ jobs:
             cache_key: anoma
             cache_version: v1
             wait_for: anoma-release (ubuntu-latest, ABCI Release build, anoma-e2e-release, v1)
-            tendermint_artifact: tendermint-unreleased-559fb33ff9b27503ce7ac1c7d8589fe1d8b3e900
+            tendermint_artifact: tendermint-unreleased-ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
 
     env:
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/build-tendermint.yml
+++ b/.github/workflows/build-tendermint.yml
@@ -23,9 +23,6 @@ jobs:
         make:
           - name: tendermint-unreleased
             repository: heliaxdev/tendermint
-            tendermint_version: 559fb33ff9b27503ce7ac1c7d8589fe1d8b3e900
-          - name: tendermint-unreleased
-            repository: heliaxdev/tendermint
             tendermint_version: ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
 
     steps:


### PR DESCRIPTION
With the shims, we will use only tendermint hash `ad825dcadbd4b98c3f91ce5a711e4fb36a69c377` for the time being.