### PR TITLE
vp_verify_masp: avoid panicking unwrap()s

### DIFF
--- a/shared/src/vm/host_env.rs
+++ b/shared/src/vm/host_env.rs
@@ -1822,22 +1822,26 @@ where
     EVAL: VpEvaluator,
     CA: WasmCacheAccess,
 {
-    use masp_primitives::transaction::Transaction;
-
     use crate::types::token::Transfer;
+
     let gas_meter = unsafe { env.ctx.gas_meter.get() };
     let (tx_bytes, gas) = env
         .memory
         .read_bytes(tx_ptr, tx_len as _)
         .map_err(|e| vp_host_fns::RuntimeError::MemoryError(Box::new(e)))?;
     vp_host_fns::add_gas(gas_meter, gas)?;
+
     let full_tx: Transfer =
-        BorshDeserialize::try_from_slice(tx_bytes.as_slice()).unwrap();
-    let shielded_tx: Transaction = full_tx.shielded.unwrap();
-    Ok(HostEnvResult::from(crate::ledger::masp::verify_shielded_tx(
-        &shielded_tx,
-    ))
-    .to_i64())
+        BorshDeserialize::try_from_slice(tx_bytes.as_slice())
+            .map_err(vp_host_fns::RuntimeError::EncodingError)?;
+
+    match full_tx.shielded {
+        Some(shielded_tx) => Ok(HostEnvResult::from(
+            crate::ledger::masp::verify_shielded_tx(&shielded_tx),
+        )
+        .to_i64()),
+        None => Ok(HostEnvResult::Fail.to_i64()),
+    }
 }
 
 /// Log a string from exposed to the wasm VM Tx environment. The message will be


### PR DESCRIPTION
Malformed transactions can cause the node to panic because this function unwraps values. Return the proper error, or a failure if asked to verify a transaction with no shielded part.