### PR TITLE
e2e/ledger_tests: fix run_ledger_load_state_and_reset in debug build

### DIFF
--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -220,11 +220,13 @@ fn run_ledger_load_state_and_reset() -> Result<()> {
     ledger.exp_string("No state could be found")?;
     // Wait to commit a block
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
+    let bg_ledger = ledger.background();
     // Wait for a new epoch
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
     epoch_sleep(&test, &validator_one_rpc, 30)?;
 
     // 2. Shut it down
+    let mut ledger = bg_ledger.foreground();
     ledger.send_control('c')?;
     // Wait for the node to stop running to finish writing the state and tx
     // queue


### PR DESCRIPTION
Follow-up to #740 which affected this test in debug build (`NAMADA_E2E_DEBUG=true`) - we have some left over `dbg!` in PoS that isn’t present in the CI as it uses release build and it fill up the process runner buffer. The `dbg!`s will be removed in another PR