### PR TITLE
test/core/storage: filter out arb keys above IBC length limit

### DIFF
--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1328,6 +1328,11 @@ pub mod testing {
         // a key from key segments
         collection::vec(arb_key_seg(), 2..5)
             .prop_map(|segments| Key { segments })
+            .prop_filter("Key length must be below IBC limit", |key| {
+                let key_str = key.to_string();
+                let bytes = key_str.as_bytes();
+                bytes.len() <= IBC_KEY_LIMIT
+            })
     }
 
     /// Generate an arbitrary [`Key`] for a given address storage sub-space.


### PR DESCRIPTION
fixes occasional false positive in test `ledger::storage::wl_storage::tests::test_prefix_iters` failing to write a key with length above the IBC limit with:

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: MerkleTreeError(StorageTreeKey(InvalidMerkleKey("Input IBC key is too large")))', core/src/ledger/storage/wl_storage.rs:484:69

As seen in e.g. https://github.com/anoma/namada/actions/runs/4512531219/jobs/7946295463

based on 0.14.2