### PR TITLE
doc/specs: remove katex renderer

### DIFF
--- a/documentation/specs/book.toml
+++ b/documentation/specs/book.toml
@@ -15,8 +15,6 @@ git-branch = "main"
 [output.html.search]
 expand = true
 
-[output.katex]
-
 [output.linkcheck]
 
 [preprocessor.katex]


### PR DESCRIPTION
Follow-up to https://github.com/anoma/namada/pull/1314 - the katex renderer is being removed in v0.5 and it seems to be failing in v0.4.0 (https://github.com/anoma/namada/actions/runs/4783109491/jobs/8503057783).

See https://github.com/lzanini/mdbook-katex/issues/68 for details.