### PR TITLE
apps/config: remove DEFAULT_BASE_DIR constant

### DIFF
--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -58,6 +58,7 @@ pub async fn join_network(
     use tokio::fs;
 
     let base_dir = global_args.base_dir;
+    let default_namada_folder = crate::config::get_default_namada_folder();
 
     // If the base-dir doesn't exist yet, create it
     if let Err(err) = fs::canonicalize(&base_dir).await {
@@ -151,7 +152,7 @@ pub async fn join_network(
     // first.
     let cwd = env::current_dir().unwrap();
     let (unpack_dir, non_default_dir) =
-        if base_dir_full != cwd.join(config::DEFAULT_BASE_DIR) {
+        if base_dir_full != cwd.join(default_namada_folder.clone()) {
             (base_dir.clone(), true)
         } else {
             (PathBuf::from_str(".").unwrap(), false)
@@ -170,7 +171,7 @@ pub async fn join_network(
             fs::rename(
                 &wasm_dir,
                 unpack_dir
-                    .join(config::DEFAULT_BASE_DIR)
+                    .join(default_namada_folder.clone())
                     .join(chain_id.as_str())
                     .join(config::DEFAULT_WASM_DIR),
             )
@@ -181,7 +182,7 @@ pub async fn join_network(
         // Move the chain dir
         fs::rename(
             unpack_dir
-                .join(config::DEFAULT_BASE_DIR)
+                .join(default_namada_folder.clone())
                 .join(chain_id.as_str()),
             &chain_dir,
         )
@@ -191,7 +192,7 @@ pub async fn join_network(
         // Move the genesis file
         fs::rename(
             unpack_dir
-                .join(config::DEFAULT_BASE_DIR)
+                .join(default_namada_folder.clone())
                 .join(format!("{}.toml", chain_id.as_str())),
             base_dir_full.join(format!("{}.toml", chain_id.as_str())),
         )
@@ -201,7 +202,7 @@ pub async fn join_network(
         // Move the global config
         fs::rename(
             unpack_dir
-                .join(config::DEFAULT_BASE_DIR)
+                .join(default_namada_folder.clone())
                 .join(config::global::FILENAME),
             base_dir_full.join(config::global::FILENAME),
         )
@@ -209,7 +210,7 @@ pub async fn join_network(
         .unwrap();
 
         // Remove the default dir
-        fs::remove_dir_all(unpack_dir.join(config::DEFAULT_BASE_DIR))
+        fs::remove_dir_all(unpack_dir.join(default_namada_folder.clone()))
             .await
             .unwrap();
     }
@@ -404,6 +405,8 @@ pub fn init_network(
 ) {
     let mut config = genesis_config::open_genesis_config(genesis_path).unwrap();
 
+    let default_namada_folder = crate::config::get_default_namada_folder();
+
     // Update the WASM checksums
     let checksums =
         wasm_loader::Checksums::read_checksums_file(&wasm_checksums_path);
@@ -428,8 +431,7 @@ pub fn init_network(
     // The `temp_chain_id` gets renamed after we have chain ID
     let accounts_dir = temp_dir.join(NET_ACCOUNTS_DIR);
     // Base dir used in account sub-directories
-    let accounts_temp_dir =
-        PathBuf::from(config::DEFAULT_BASE_DIR).join(temp_chain_id.as_str());
+    let accounts_temp_dir = default_namada_folder.join(temp_chain_id.as_str());
 
     let mut rng: ThreadRng = thread_rng();
 
@@ -668,7 +670,7 @@ pub fn init_network(
             .join(chain_id.as_str())
             .join(NET_ACCOUNTS_DIR)
             .join(name)
-            .join(config::DEFAULT_BASE_DIR);
+            .join(default_namada_folder.clone());
         let temp_validator_chain_dir =
             validator_dir.join(temp_chain_id.as_str());
         let validator_chain_dir = validator_dir.join(chain_id.as_str());
@@ -703,7 +705,7 @@ pub fn init_network(
         |(ix, (name, validator_config))| {
             let accounts_dir = chain_dir.join(NET_ACCOUNTS_DIR);
             let validator_dir =
-                accounts_dir.join(name).join(config::DEFAULT_BASE_DIR);
+                accounts_dir.join(name).join(default_namada_folder.clone());
             let mut config = Config::load(
                 &validator_dir,
                 &chain_id,
@@ -717,7 +719,7 @@ pub fn init_network(
             // parameter. We need to remove this prefix, because
             // these sub-directories will be moved to validators' root
             // directories.
-            config.ledger.shell.base_dir = config::DEFAULT_BASE_DIR.into();
+            config.ledger.shell.base_dir = default_namada_folder.clone();
             // Add a ledger P2P persistent peers
             config.ledger.tendermint.p2p_persistent_peers = persistent_peers
                     .iter()
@@ -795,14 +797,14 @@ pub fn init_network(
     // Create a release tarball for anoma-network-config
     if !dont_archive {
         let mut release = tar::Builder::new(Vec::new());
-        let release_genesis_path = PathBuf::from(config::DEFAULT_BASE_DIR)
-            .join(format!("{}.toml", chain_id.as_str()));
+        let release_genesis_path =
+            default_namada_folder.join(format!("{}.toml", chain_id.as_str()));
         release
             .append_path_with_name(genesis_path, release_genesis_path)
             .unwrap();
         let global_config_path = GlobalConfig::file_path(&global_args.base_dir);
         let release_global_config_path =
-            GlobalConfig::file_path(config::DEFAULT_BASE_DIR);
+            GlobalConfig::file_path(default_namada_folder.clone());
         release
             .append_path_with_name(
                 global_config_path,
@@ -812,15 +814,14 @@ pub fn init_network(
         let chain_config_path =
             Config::file_path(&global_args.base_dir, &chain_id);
         let release_chain_config_path =
-            Config::file_path(config::DEFAULT_BASE_DIR, &chain_id);
+            Config::file_path(default_namada_folder.clone(), &chain_id);
         release
             .append_path_with_name(chain_config_path, release_chain_config_path)
             .unwrap();
-        let release_wasm_checksums_path =
-            PathBuf::from(config::DEFAULT_BASE_DIR)
-                .join(chain_id.as_str())
-                .join(config::DEFAULT_WASM_DIR)
-                .join(config::DEFAULT_WASM_CHECKSUMS_FILE);
+        let release_wasm_checksums_path = default_namada_folder
+            .join(chain_id.as_str())
+            .join(config::DEFAULT_WASM_DIR)
+            .join(config::DEFAULT_WASM_CHECKSUMS_FILE);
         release
             .append_path_with_name(
                 &wasm_checksums_path,

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -20,8 +20,6 @@ use crate::cli;
 use crate::facade::tendermint::Timeout;
 use crate::facade::tendermint_config::net::Address as TendermintAddress;
 
-/// Base directory contains global config and chain directories.
-pub const DEFAULT_BASE_DIR: &str = ".namada";
 /// Default WASM dir.
 pub const DEFAULT_WASM_DIR: &str = "wasm";
 /// The WASM checksums file contains the hashes of built WASMs. It is inside the
@@ -353,7 +351,10 @@ pub fn get_default_namada_folder() -> PathBuf {
     if let Some(project_dir) = ProjectDirs::from("com", "heliax", "namada") {
         project_dir.data_dir().to_path_buf()
     } else {
-        DEFAULT_BASE_DIR.into()
+        // In extremis, default to the old behavior of simply using the path
+        // ".namada" as the base directory. This will only occur in
+        // pathological situations where no user home directory exists.
+        ".namada".into()
     }
 }
 

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -412,6 +412,7 @@ impl Test {
     }
 
     pub fn get_base_dir(&self, who: &Who) -> PathBuf {
+        let default_namada_folder = config::get_default_namada_folder();
         match who {
             Who::NonValidator => self.test_dir.path().to_owned(),
             Who::Validator(index) => self
@@ -420,7 +421,7 @@ impl Test {
                 .join(self.net.chain_id.as_str())
                 .join(utils::NET_ACCOUNTS_DIR)
                 .join(format!("validator-{}", index))
-                .join(config::DEFAULT_BASE_DIR),
+                .join(default_namada_folder),
         }
     }
 }
@@ -888,11 +889,12 @@ pub fn copy_wasm_to_chain_dir<'a>(
     }
 
     // Copy the built WASM files from "wasm" directory to each validator dir
+    let default_namada_folder = config::get_default_namada_folder();
     for validator_name in genesis_validator_keys {
         let target_wasm_dir = chain_dir
             .join(utils::NET_ACCOUNTS_DIR)
             .join(validator_name)
-            .join(config::DEFAULT_BASE_DIR)
+            .join(default_namada_folder.clone())
             .join(chain_id.as_str())
             .join(config::DEFAULT_WASM_DIR);
         for file in &wasm_files {


### PR DESCRIPTION
Now that Namada defaults to platform-compliant (e.g. XDG) default data
directories, the DEFAULT_BASE_DIR constant (".namada") should no longer
exist. Remove it, using get_default_namada_folder() in places which
referenced it.

The ultimate fallback in case get_default_namada_folder() fails remains
".namada", but this is now just a string inside
get_default_namada_folder(). This will not happen except in
pathological cases where e.g. no $HOME exists; the details are in the
documentation for the directories crate.
