### PR TITLE
ci: remove clippy-abcipp check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,10 +29,6 @@ jobs:
         os: [ubuntu-20.04]
         nightly_version: [nightly-2022-11-03]
         make:
-          - name: Check ABCI++
-            command: check-abcipp
-            cache_subkey: abcipp
-            cache_version: v1
           - name: Clippy
             command: clippy
             cache_subkey: clippy


### PR DESCRIPTION
SDK is going to break the abci++ build, and the consensus on whether we
care is that we don't and should consider removing abci++ anyway.
Therefore, disable this check so we are ready for SDK.
