### PR TITLE
feat: replace http-client feature with trait-client(for wasm32 build)

### DIFF
--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -129,7 +129,7 @@ tendermint-abcipp = {package = "tendermint", git = "https://github.com/heliaxdev
 tendermint-rpc-abcipp = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "4db3c5ea09fae4057008d22bf9e96bf541b55b35", features = ["http-client"], optional = true}
 tendermint-proto-abcipp = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "4db3c5ea09fae4057008d22bf9e96bf541b55b35", optional = true}
 tendermint = {version = "0.23.6", optional = true}
-tendermint-rpc = {version = "0.23.6", features = ["http-client"], optional = true}
+tendermint-rpc = {version = "0.23.6", default-features = false, features = ["trait-client"], optional = true}
 tendermint-proto = {version = "0.23.6", optional = true}
 thiserror = "1.0.38"
 tracing = "0.1.30"


### PR DESCRIPTION
Replacing `http-client` with `trait-client` so wasm32 build does not fail.