### PR TITLE
portable build_network.sh

### DIFF
--- a/scripts/build_network.sh
+++ b/scripts/build_network.sh
@@ -1,10 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Script for initializing a Namada chain for local development and joining it.
 # Note that this script trashes any existing local chain directories!
 #
 # ## Prerequisites
-# - bash
 # - Python 3
 # - toml Python pip library <https://pypi.org/project/toml/> (this is the
 #   `python3-toml` package on Ubuntu distributions)
@@ -62,7 +61,7 @@ check_toml_file() {
     section_prefix="validator.validator"
     # Search for the section name in the TOML file
     section_count=$(awk -F'[][]' -v prefix="$section_prefix" '/^\[.*\]$/ && $2 ~ "^" prefix { count++ } END { print count }' "$toml_file")
-    if [[ ! $section_count -eq 0 ]]; then
+    if [ ! "$section_count" -eq 0 ]; then
         echo "At least one validator ($section_count, in fact) has been found in the toml file. Please delete all occurrences of the section '[$section_prefix]' in the TOML file and try again."
         exit 1
     fi
@@ -74,7 +73,7 @@ check_wasm_files() {
 
     count=$(echo "$wasm_files" | wc -l)
 
-    if [[ ! $count -ge 5 ]]; then
+    if [ ! "$count" -ge 5 ]; then
         echo "You must run make build-wasm-scripts in the namada directory before running this script."
         exit 1
     fi
@@ -209,7 +208,7 @@ package() {
 }
 
 main() {    
-    if [[ "$*" == *"--help"* ]]; then
+    if expr "x$*x" : "x*--help*x" >/dev/null; then
         show_help
         return 0
     fi


### PR DESCRIPTION
- scripts/build_network: remove spurious field separators
  The default value of $IFS (internal field separator) is space, tab,
  and newline. When de-bashifying this script, this line will change
  its meaning to make the literal characters 'n' and 't' field
  separators, causing heinous errors (for example, the word "network"
  is likely to show up, which contains an 'n' and a 't').

  But the line serves no purpose here, so remove it.

- scripts/build_network: port to posix shell
  Bash is a popular interactive shell, but it is not a suitable target
  for shell scripts. Remove bashisms.

  Tested on dash (Debian Almquist Shell) but not extensively across
  systems.
