### PR TITLE
chore: add basic shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import<nixpkgs> {} }: pkgs.mkShell{
+  nativeBuildInputs = with pkgs; [pkg-config rustPlatform.bindgenHook];
+  buildInputs = with pkgs; [systemdMinimal.dev libclang.lib];
+  LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+}


### PR DESCRIPTION
## Describe your changes

Under NixOS, we use this `shell.nix` to provide the basic build dependencies (except for Rust itself, which we get with `rustup` like on other systems).

* Without it:
```
$ cargo doc
# ... *build build build*...
error: failed to run custom build command for `hidapi v1.5.0`                                                                                                                                                        
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.                                                 
                                                                                                                                                                                                                     
Caused by:                                                                                                                                                                                                           
  process didn't exit successfully: `/home/user/Lab/Namada/namada/target/debug/build/hidapi-9d905abdd1e8f2ea/build-script-build` (exit status: 101)                                                                  
  --- stdout                                                                                                                                                                                                         
  cargo:rerun-if-env-changed=LIBUDEV_NO_PKG_CONFIG                                                                                                                                                                   
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu                                                                                                                                                     
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu                                                                                                                                                     
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG                                                                                                                                                                         
  cargo:rerun-if-env-changed=PKG_CONFIG                                                                                                                                                                              
  cargo:rerun-if-env-changed=LIBUDEV_STATIC                                                                                                                                                                          
  cargo:rerun-if-env-changed=LIBUDEV_DYNAMIC                                                                                                                                                                         
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC                                                                                                                                                                   
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC                                                                                                                                                                  
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu                                                                                                                                                
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu                                                                                                                                                
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH                                                                                                                                                                    
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH                                                                                                                                                                         
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu                                                                                                                                              
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu                                                                                                                                              
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR                                                                                                                                                                  
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR                                                                                                                                                                       
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu                                                                                                                                         
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu                                                                                                                                         
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR                                                                                                                                                             
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR                                                                                                                                                                  
                                                                                                                                                                                                                     
  --- stderr                                                                                                                                                                                                         
  thread 'main' panicked at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hidapi-1.5.0/build.rs:57:54:                                                                                             
  Unable to find libudev: `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS="1" PKG_CONFIG_ALLOW_SYSTEM_LIBS="1" "pkg-config" "--libs" "--cflags" "libudev"` did not exit successfully: exit status: 1                                 
  error: could not find system library 'libudev' required by the 'hidapi' crate                                                                                                                                      
                                                                                                                                                                                                                     
  --- stderr                                                                                                                                                                                                         
  Package libudev was not found in the pkg-config search path.                                                                                                                                                       
  Perhaps you should add the directory containing `libudev.pc'                                                                                                                                                       
  to the PKG_CONFIG_PATH environment variable                                                                                                                                                                        
  No package 'libudev' found                                                                                                                                                                                         
                                                                                                                                                                                                                     
  stack backtrace:                                                                                                                                                                                                   
     0: rust_begin_unwind                                                                                                                                                                                            
               at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panicking.rs:652:5                                                                                                                 
     1: core::panicking::panic_fmt                                                                                                                                                                                   
               at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/panicking.rs:72:14                                                                                                                
     2: core::result::unwrap_failed                                                                                                                                                                                  
               at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/result.rs:1679:5                                                                                                                  
     3: core::result::Result<T,E>::expect                                                                                                                                                                            
     4: build_script_build::compile_linux::{{closure}}                                                                                                                                                               
     5: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
     6: build_script_build::compile_linux
     7: build_script_build::main
     8: core::ops::function::FnOnce::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
warning: build failed, waiting for other jobs to finish...
```

* With it:
```
$ nix-shell
$ cargo doc
# ... build build build...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 23m 19s                                                                                                                                            
   Generated /home/user/Lab/Namada/namada/target/doc/namada_account/index.html and 35 other files 
# all done!
```

## Checklist before merging 
- [x] No consensus-breaking changes
- [x] No changes to docs or specs
- [x] No services affected