### PR TITLE
Revert "ci(mergify): upgrade configuration to current format"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,21 +2,6 @@ merge_queue:
   max_parallel_checks: 3
 
 queue_rules:
-  - name: duplicated main-queue from automatic merge to main or backport branch
-    batch_size: 3
-    queue_conditions:
-      - "#approved-reviews-by >= 1"
-      - base = main
-      - label = "merge"
-      - label != "do-not-merge"
-      - "#approved-reviews-by >= 1"
-      - &id001
-        or:
-          - base = main
-          - base = maint-0.46
-    merge_conditions: []
-    merge_method: merge
-    autosquash: true
   - name: main-queue
     batch_size: 3
     queue_conditions:
@@ -24,19 +9,6 @@ queue_rules:
       - base = main
     merge_method: merge
 
-  - name: duplicated backport-0.46-queue from automatic merge to main or backport
-      branch
-    batch_size: 3
-    queue_conditions:
-      - "#approved-reviews-by >= 1"
-      - base = maint-0.46
-      - label = "merge"
-      - label != "do-not-merge"
-      - "#approved-reviews-by >= 1"
-      - *id001
-    merge_conditions: []
-    merge_method: merge
-    autosquash: true
   - name: backport-0.46-queue
     batch_size: 3
     queue_conditions:
@@ -44,12 +16,23 @@ queue_rules:
       - base = maint-0.46
     merge_method: merge
 
-
 pull_request_rules:
+  - name: automatic merge to main or backport branch
+    conditions:
+        - label = "merge"
+        - label != "do-not-merge"
+        - "#approved-reviews-by >= 1"
+        - or:
+          - base = main
+          - base = maint-0.46
+    actions:
+      queue:
+        autosquash: true   
+
   - name: notify when a PR is removed from the queue
     conditions:
-      - queue-dequeue-reason != none
-      - queue-dequeue-reason != pr-merged
+    - queue-dequeue-reason != none
+    - queue-dequeue-reason != pr-merged
     actions:
       comment:
         message: >
@@ -66,7 +49,3 @@ pull_request_rules:
       backport:
         branches:
           - "maint-0.46"
-  - name: refactored queue action rule
-    conditions: []
-    actions:
-      queue:


### PR DESCRIPTION
This reverts commit 63eaf11a0a1fb17df96da420f42555057adb3b37 from bing bong #4062

## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
