### PR TITLE
declare internal dev-dependencies via path

### DIFF
--- a/crates/account/Cargo.toml
+++ b/crates/account/Cargo.toml
@@ -31,6 +31,6 @@ proptest = { workspace = true, optional = true }
 serde.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
+namada_core = { path = "../core", features = ["testing"] }
 
 proptest.workspace = true

--- a/crates/apps_lib/Cargo.toml
+++ b/crates/apps_lib/Cargo.toml
@@ -84,7 +84,7 @@ tracing.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
-namada_sdk = { workspace = true, default-features = true, features = [
+namada_sdk = { path = "../sdk", default-features = true, features = [
   "testing",
 ] }
 

--- a/crates/ethereum_bridge/Cargo.toml
+++ b/crates/ethereum_bridge/Cargo.toml
@@ -52,17 +52,15 @@ thiserror.workspace = true
 tracing = "0.1.30"
 
 [dev-dependencies]
-namada_account.workspace = true
-namada_core = { workspace = true, features = ["ethers-derive", "testing"] }
-namada_gas.workspace = true
-namada_governance.workspace = true
-namada_proof_of_stake = { workspace = true, features = ["testing"] }
-namada_state = { workspace = true, features = ["testing"] }
-namada_token = { workspace = true, features = ["testing"] }
-namada_tx = { workspace = true, features = ["testing"] }
-namada_vm = { workspace = true, default-features = true, features = [
-    "testing",
-] }
+namada_account.path = "../account"
+namada_core = { path = "../core", features = ["ethers-derive", "testing"] }
+namada_gas.path = "../gas"
+namada_governance.path = "../governance"
+namada_proof_of_stake = { path = "../proof_of_stake", features = ["testing"] }
+namada_state = { path = "../state", features = ["testing"] }
+namada_token = { path = "../token", features = ["testing"] }
+namada_tx = { path = "../tx", features = ["testing"] }
+namada_vm = { path = "../vm", default-features = true, features = ["testing"] }
 namada_vp.workspace = true
 
 assert_matches.workspace = true

--- a/crates/governance/Cargo.toml
+++ b/crates/governance/Cargo.toml
@@ -42,17 +42,15 @@ tracing.workspace = true
 
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
-namada_gas.workspace = true
-namada_parameters.workspace = true
-namada_proof_of_stake = { workspace = true, features = ["testing"] }
-namada_state = { workspace = true, features = ["testing"] }
-namada_token = { workspace = true, features = ["testing"] }
-namada_tx = { workspace = true, features = ["testing"] }
-namada_vm = { workspace = true, default-features = true, features = [
-    "testing",
-] }
-namada_vp.workspace = true
+namada_core = { path = "../core", features = ["testing"] }
+namada_gas.path = "../gas"
+namada_parameters.path = "../parameters"
+namada_proof_of_stake = { path = "../proof_of_stake", features = ["testing"] }
+namada_state = { path = "../state", features = ["testing"] }
+namada_token = { path = "../token", features = ["testing"] }
+namada_tx = { path = "../tx", features = ["testing"] }
+namada_vm = { path = "../vm", default-features = true, features = ["testing"] }
+namada_vp.path = "../vp"
 
 assert_matches.workspace = true
 proptest.workspace = true

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -60,16 +60,14 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
-namada_governance.workspace = true
-namada_parameters = { workspace = true, features = ["testing"] }
-namada_proof_of_stake = { workspace = true, features = ["testing"] }
-namada_state = { workspace = true, features = ["testing"] }
-namada_token.workspace = true
-namada_tx = { workspace = true, features = ["testing"] }
-namada_vm = { workspace = true, default-features = true, features = [
-  "testing",
-] }
+namada_core = { path = "../core", features = ["testing"] }
+namada_governance.path = "../governance"
+namada_parameters = { path = "../parameters", features = ["testing"] }
+namada_proof_of_stake = { path = "../proof_of_stake", features = ["testing"] }
+namada_state = { path = "../state", features = ["testing"] }
+namada_token.path = "../token"
+namada_tx = { path = "../tx", features = ["testing"] }
+namada_vm = { path = "../vm", default-features = true, features = ["testing"] }
 
 assert_matches.workspace = true
 ibc-testkit.workspace = true

--- a/crates/merkle_tree/Cargo.toml
+++ b/crates/merkle_tree/Cargo.toml
@@ -30,7 +30,7 @@ prost.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
+namada_core = { path = "../core", features = ["testing"] }
 
 assert_matches.workspace = true
 proptest.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -104,11 +104,9 @@ warp = "0.3.2"
 zstd.workspace = true
 
 [dev-dependencies]
-namada_apps_lib = { workspace = true, features = ["testing"] }
-namada_test_utils.workspace = true
-namada_vm = { workspace = true, default-features = true, features = [
-  "testing",
-] }
+namada_apps_lib = { path = "../apps_lib", features = ["testing"] }
+namada_test_utils.path = "../test_utils"
+namada_vm = { path = "../vm", default-features = true, features = ["testing"] }
 
 assert_matches.workspace = true
 clap.workspace = true

--- a/crates/parameters/Cargo.toml
+++ b/crates/parameters/Cargo.toml
@@ -28,4 +28,4 @@ smooth-operator.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-namada_state = { workspace = true, features = ["testing"] }
+namada_state = { path = "../state", features = ["testing"] }

--- a/crates/proof_of_stake/Cargo.toml
+++ b/crates/proof_of_stake/Cargo.toml
@@ -42,12 +42,12 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
-namada_events = { workspace = true, features = ["testing"] }
-namada_governance.workspace = true
-namada_parameters.workspace = true
-namada_state = { workspace = true, features = ["testing"] }
-namada_trans_token.workspace = true
+namada_core = { path = "../core", features = ["testing"] }
+namada_events = { path = "../events", features = ["testing"] }
+namada_governance.path = "../governance"
+namada_parameters.path = "../parameters"
+namada_state = { path = "../state", features = ["testing"] }
+namada_trans_token.path = "../trans_token"
 
 assert_matches.workspace = true
 itertools.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -147,23 +147,22 @@ tokio = { workspace = true, features = ["full"] }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 
 [dev-dependencies]
-namada_account = { workspace = true, features = ["testing"] }
-namada_core = { workspace = true, features = ["rand", "testing"] }
-namada_ethereum_bridge = { workspace = true, features = ["testing"] }
-namada_governance = { workspace = true, features = ["testing"] }
-namada_ibc = { workspace = true, features = ["testing"] }
-namada_parameters.workspace = true
-namada_proof_of_stake = { workspace = true, features = ["testing"] }
-namada_state = { workspace = true, features = ["testing"] }
-namada_storage = { workspace = true, features = ["testing"] }
-namada_token = { workspace = true, features = ["testing", "masp"] }
-namada_tx = { workspace = true, features = ["testing"] }
-namada_vm.workspace = true
-namada_vote_ext.workspace = true
-namada_vp.workspace = true
+namada_account = { path = "../account", features = ["testing"] }
+namada_core = { path = "../core", features = ["rand", "testing"] }
+namada_ethereum_bridge = { path = "../ethereum_bridge", features = ["testing"] }
+namada_governance = { path = "../governance", features = ["testing"] }
+namada_ibc = { path = "../ibc", features = ["testing"] }
+namada_parameters.path = "../parameters"
+namada_proof_of_stake = { path = "../proof_of_stake", features = ["testing"] }
+namada_state = { path = "../state", features = ["testing"] }
+namada_storage = { path = "../storage", features = ["testing"] }
+namada_token = { path = "../token", features = ["testing", "masp"] }
+namada_tx = { path = "../tx", features = ["testing"] }
+namada_vm.path = "../vm"
+namada_vote_ext.path = "../vote_ext"
+namada_vp.path = "../vp"
 
 assert_matches.workspace = true
-
 jubjub.workspace = true
 masp_primitives = { workspace = true, features = ["test-dependencies"] }
 proptest.workspace = true

--- a/crates/shielded_token/Cargo.toml
+++ b/crates/shielded_token/Cargo.toml
@@ -78,16 +78,14 @@ xorf.workspace = true
 
 
 [dev-dependencies]
-namada_gas.workspace = true
-namada_governance = { workspace = true, features = ["testing"] }
-namada_ibc = { workspace = true, features = ["testing"] }
-namada_parameters = { workspace = true, features = ["testing"] }
-namada_state = { workspace = true, features = ["testing"] }
-namada_trans_token.workspace = true
-namada_vm = { workspace = true, default-features = true, features = [
-  "testing",
-] }
-namada_vp.workspace = true
+namada_gas.path = "../gas"
+namada_governance = { path = "../governance", features = ["testing"] }
+namada_ibc = { path = "../ibc", features = ["testing"] }
+namada_parameters = { path = "../parameters", features = ["testing"] }
+namada_state = { path = "../state", features = ["testing"] }
+namada_trans_token.path = "../trans_token"
+namada_vm = { path = "../vm", default-features = true, features = ["testing"] }
+namada_vp.path = "../vp"
 
 lazy_static.workspace = true
 masp_primitives = { workspace = true, features = ["test-dependencies"] }

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -53,9 +53,9 @@ patricia_tree.workspace = true
 proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
-namada_merkle_tree = { workspace = true, features = ["testing"] }
-namada_parameters = { workspace = true, features = ["testing"] }
+namada_core = { path = "../core", features = ["testing"] }
+namada_merkle_tree = { path = "../merkle_tree", features = ["testing"] }
+namada_parameters = { path = "../parameters", features = ["testing"] }
 
 assert_matches.workspace = true
 chrono.workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -35,4 +35,4 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
+namada_core = { path = "../core", features = ["testing"] }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -58,14 +58,14 @@ tokio = { workspace = true, features = ["full"] }
 wasmer.workspace = true
 
 [dev-dependencies]
-namada_apps_lib = { workspace = true, features = ["testing"] }
-namada_node = { workspace = true, features = ["testing"] }
-namada_sdk = { workspace = true, default-features = false, features = [
+namada_apps_lib = { path = "../apps_lib", features = ["testing"] }
+namada_node = { path = "../node", features = ["testing"] }
+namada_sdk = { path = "../sdk", default-features = false, features = [
   "download-params",
   "testing",
   "migrations",
 ] }
-namada_vm_env.workspace = true
+namada_vm_env.path = "../vm_env"
 
 assert_cmd.workspace = true
 assert_matches.workspace = true

--- a/crates/token/Cargo.toml
+++ b/crates/token/Cargo.toml
@@ -48,9 +48,9 @@ proptest = { workspace = true, optional = true }
 serde.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
-namada_shielded_token = { workspace = true, features = ["testing"] }
-namada_tests.workspace = true
+namada_core = { path = "../core", features = ["testing"] }
+namada_shielded_token = { path = "../shielded_token", features = ["testing"] }
+namada_tests.path = "../tests"
 
 masp_primitives.workspace = true
 

--- a/crates/trans_token/Cargo.toml
+++ b/crates/trans_token/Cargo.toml
@@ -31,18 +31,18 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
-namada_gas.workspace = true
-namada_governance = { workspace = true, features = ["testing"] }
-namada_ibc = { workspace = true, features = ["testing"] }
-namada_parameters = { workspace = true, features = ["testing"] }
-namada_state = { workspace = true, features = ["testing"] }
-namada_tests.workspace = true
-namada_tx = { workspace = true, features = ["testing"] }
-namada_vm = { workspace = true, default-features = true, features = [
+namada_core = { path = "../core", features = ["testing"] }
+namada_gas.path = "../gas"
+namada_governance = { path = "../governance", features = ["testing"] }
+namada_ibc = { path = "../ibc", features = ["testing"] }
+namada_parameters = { path = "../parameters", features = ["testing"] }
+namada_state = { path = "../state", features = ["testing"] }
+namada_tests.path = "../tests"
+namada_tx = { path = "../tx", features = ["testing"] }
+namada_vm = { path = "../vm", default-features = true, features = [
     "testing",
 ] }
-namada_vp.workspace = true
+namada_vp.path = "../vp"
 
 assert_matches.workspace = true
 itertools.workspace = true

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -51,7 +51,7 @@ sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
+namada_core = { path = "../core", features = ["testing"] }
 
 assert_matches.workspace = true
 proptest.workspace = true

--- a/crates/tx_prelude/Cargo.toml
+++ b/crates/tx_prelude/Cargo.toml
@@ -35,4 +35,4 @@ namada_vm_env.workspace = true
 borsh.workspace = true
 
 [dev-dependencies]
-namada_token = { workspace = true, features = ["testing"] }
+namada_token = { path = "../token", features = ["testing"] }

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -52,12 +52,10 @@ wasmer-vm = { workspace = true, optional = true }
 wasmparser.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, features = [
-  "testing",
-] }
-namada_state = { workspace = true, features = ["testing"] }
-namada_test_utils.workspace = true
-namada_tx = { workspace = true, features = ["testing"] }
+namada_core = { path = "../core", features = ["testing"] }
+namada_state = { path = "../state", features = ["testing"] }
+namada_test_utils.path = "../test_utils"
+namada_tx = { path = "../tx", features = ["testing"] }
 
 assert_matches.workspace = true
 byte-unit.workspace = true

--- a/crates/vote_ext/Cargo.toml
+++ b/crates/vote_ext/Cargo.toml
@@ -26,6 +26,6 @@ linkme = { workspace = true, optional = true }
 serde.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, features = ["testing"] }
+namada_core = { path = "../core", features = ["testing"] }
 
 data-encoding.workspace = true

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -44,5 +44,6 @@ toml.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"]}
+namada_core = { path = "../core", features = ["testing"] }
+
 base58.workspace = true


### PR DESCRIPTION
This is a workaround for https://github.com/rust-lang/cargo/issues/4242

## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
