### PR TITLE
Display payment addresses instead of extended full viewing keys in test vectors

### DIFF
--- a/.changelog/unreleased/improvements/4436-compress-hw-displays.md
+++ b/.changelog/unreleased/improvements/4436-compress-hw-displays.md
@@ -1,0 +1,3 @@
+- Display payment addresses instead of extended full
+  viewing keys on the hardware wallet to save screen space.
+  ([\#4436](https://github.com/anoma/namada/pull/4436))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ env:
   AWS_REGION: us-west-2
   NIGHTLY: nightly-2024-09-08
   NAMADA_MASP_PARAMS_DIR: /masp/.masp-params
-  LEDGER_APP_VERSION: "3.0.4"
+  LEDGER_APP_VERSION: "3.0.7"
   ROLE: arn:aws:iam::375643557360:role/github-runners-ci-shared
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4948,7 +4948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5088,9 +5088,9 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+checksum = "7b136637896ff0e2a9f18f25464eb8cc75dde909ab616918d3e13ab7401ab89a"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -5103,9 +5103,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+checksum = "c6c3739b3b1a5e767ad88a38c9000cf8014e5fab84b93c4e9415e10a56cede54"
 dependencies = [
  "aes",
  "arbitrary",
@@ -5137,9 +5137,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+checksum = "131fd70050405eb3cfd45e704982a1b44fafc9443dbb352d079ccf1c1cda53c9"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,8 +189,8 @@ libfuzzer-sys = "0.4"
 libloading = "0.8"
 linkme = "0.3"
 madato = "0.7"
-masp_primitives = { version = "1.2" }
-masp_proofs = { version = "1.2", default-features = false, features = ["local-prover"] }
+masp_primitives = { version = "1.3.0" }
+masp_proofs = { version = "1.3.0", default-features = false, features = ["local-prover"] }
 num256 = "0.6"
 num_cpus = "1.13"
 num_enum = "0.7"

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -18,9 +18,7 @@ use namada_core::arith::checked;
 use namada_core::collections::{HashMap, HashSet};
 use namada_core::ibc::primitives::IntoHostTime;
 use namada_core::key::*;
-use namada_core::masp::{
-    AssetData, ExtendedViewingKey, MaspTxId, PaymentAddress,
-};
+use namada_core::masp::{AssetData, MaspTxId, PaymentAddress};
 use namada_core::tendermint::Time as TmTime;
 use namada_core::time::DateTimeUtc;
 use namada_core::token::{Amount, DenominatedAmount};
@@ -845,8 +843,11 @@ async fn make_ledger_token_transfer_endpoints(
     }
     if let Some(builder) = builder {
         for sapling_input in builder.builder.sapling_inputs() {
-            let vk = ExtendedViewingKey::from(*sapling_input.key());
-            output.push(format!("Sender : {}", vk));
+            let pa = sapling_input.address().ok_or_else(|| {
+                Error::Other("unable to load vp code".to_string())
+            })?;
+            let pa = PaymentAddress::from(pa);
+            output.push(format!("Sender : {}", pa));
             make_ledger_amount_asset(
                 tokens,
                 output,

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -4083,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+checksum = "7b136637896ff0e2a9f18f25464eb8cc75dde909ab616918d3e13ab7401ab89a"
 dependencies = [
  "borsh",
  "chacha20",
@@ -4097,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+checksum = "c6c3739b3b1a5e767ad88a38c9000cf8014e5fab84b93c4e9415e10a56cede54"
 dependencies = [
  "aes",
  "bip0039",
@@ -4130,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+checksum = "131fd70050405eb3cfd45e704982a1b44fafc9443dbb352d079ccf1c1cda53c9"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2273,9 +2273,9 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+checksum = "7b136637896ff0e2a9f18f25464eb8cc75dde909ab616918d3e13ab7401ab89a"
 dependencies = [
  "borsh",
  "chacha20",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+checksum = "c6c3739b3b1a5e767ad88a38c9000cf8014e5fab84b93c4e9415e10a56cede54"
 dependencies = [
  "aes",
  "bip0039",
@@ -2319,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+checksum = "131fd70050405eb3cfd45e704982a1b44fafc9443dbb352d079ccf1c1cda53c9"
 dependencies = [
  "bellman",
  "blake2b_simd",


### PR DESCRIPTION
## Describe your changes
An attempt to reduce the amount of screens clicked through on the hardware wallet for shielded/unshielding transactions. This is done by displaying the payment address of a note as the sender (similar to what the Zcash Ledger app does) instead of the extended full viewing key that owns it. This reduces the number of screens required to display a sender from 8 to 3. I.e. there's now 5 less screens to click though, which reduces the amount of time required to sign a shielded transaction once the display lag is considered. Alternative options were considered like displaying just a full viewing key or an incoming viewing key instead of the extended full viewing key, but these do not already have bech32 encodings in Namada nor can they be used in any of the existing interfaces. See attached what the new test vectors would look like: [testvecs-fmted.json.gz](https://github.com/user-attachments/files/19145646/testvecs-fmted.json.gz) and [testdbgs.txt.gz](https://github.com/user-attachments/files/19145647/testdbgs.txt.gz).

This PR depends upon https://github.com/anoma/masp/pull/92 to obtain the payment addresses of transaction input notes.
## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
