### PR TITLE
Revert "mergify: merge and update with rebase to allow auto-squash"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,27 +7,24 @@ queue_rules:
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - base = main
-    merge_method: rebase
-    update_method: rebase
-    autosquash: true # requires `update_method: rebase`
+    merge_method: merge
+    autosquash: true   
 
   - name: backport-apps-1.1-queue
     batch_size: 3
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - base = maint-1.1
-    merge_method: rebase
-    update_method: rebase
-    autosquash: true # requires `update_method: rebase`
+    merge_method: merge
+    autosquash: true   
 
   - name: backport-libs-0.48-queue
     batch_size: 3
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - base = maint-libs-0.48
-    merge_method: rebase
-    update_method: rebase
-    autosquash: true # requires `update_method: rebase`
+    merge_method: merge
+    autosquash: true   
 
 pull_request_rules:
   - name: automatic merge to main or backport branch


### PR DESCRIPTION
This reverts #4426, cause it doesn't create merge commits

## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
