### PR TITLE
cargo: reduce the MSRV to 1.83

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ license = "GPL-3.0"
 readme = "README.md"
 repository = "https://github.com/anoma/namada"
 version = "0.48.0"
-rust-version = "1.85.1"
+rust-version = "1.83" # MSRV
 
 [workspace.dependencies]
 namada_account = { version = "0.48.0", path = "crates/account" }


### PR DESCRIPTION
## Describe your changes

fix follow for #4439 

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
