### PR TITLE
CI: bump maint version libs-v0.49 and apps-101.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,9 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MINOR_VERSION_RELEASE: "0.48.999" # bump on a major release
-  BACKPORT_LIBS_LABEL: "backport-libs-0.48" # also bump on major release
-  MAINT_LIBS_BRANCH: "maint-libs-0.48" # also bump on major release
+  MINOR_VERSION_RELEASE: "0.149.999" # bump on a major release
+  BACKPORT_LIBS_LABEL: "backport-libs-0.149" # also bump on major release
+  MAINT_LIBS_BRANCH: "maint-libs-0.149" # also bump on major release
 
 jobs:
   # Check if a PR has no major breaking changes to be backported to library

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,19 +10,19 @@ queue_rules:
     merge_method: merge
     autosquash: true   
 
-  - name: backport-apps-1.1-queue
+  - name: backport-apps-101.0-queue
     batch_size: 3
     queue_conditions:
       - "#approved-reviews-by >= 1"
-      - base = maint-1.1
+      - base = maint-101.0
     merge_method: merge
     autosquash: true   
 
-  - name: backport-libs-0.48-queue
+  - name: backport-libs-0.149-queue
     batch_size: 3
     queue_conditions:
       - "#approved-reviews-by >= 1"
-      - base = maint-libs-0.48
+      - base = maint-libs-0.149
     merge_method: merge
     autosquash: true   
 
@@ -34,8 +34,8 @@ pull_request_rules:
       - "#approved-reviews-by >= 1"
       - or:
         - base = main
-        - base = maint-1.1
-        - base = maint-libs-0.48
+        - base = maint-101.0
+        - base = maint-libs-0.149
     actions:
       queue:
 
@@ -52,18 +52,18 @@ pull_request_rules:
           Sorry about that, but you can requeue the PR by using `@mergifyio requeue`
           if you think this was a mistake.
 
-  - name: backport PR to apps 1.1 lane
+  - name: backport PR to apps 101.0 lane
     conditions:
-      - label = backport-1.1
+      - label = backport-101.0
     actions:
       backport:
         branches:
-          - "maint-1.1"
+          - "maint-101.0"
 
-  - name: backport PR to libs 0.48 lane
+  - name: backport PR to libs 0.149 lane
     conditions:
-      - label = backport-libs-0.48
+      - label = backport-libs-0.149
     actions:
       backport:
         branches:
-          - "maint-libs-0.48"
+          - "maint-libs-0.149"


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
