### PR TITLE
Indexer client backoff sleep

### DIFF
--- a/.changelog/unreleased/improvements/4702-indexer-client-backoff-sleep.md
+++ b/.changelog/unreleased/improvements/4702-indexer-client-backoff-sleep.md
@@ -1,0 +1,2 @@
+- Add backoff sleep between MASP indexer client failed requests.
+  ([\#4702](https://github.com/anoma/namada/pull/4702))

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -21,7 +21,9 @@ use namada_token::masp::shielded_wallet::ShieldedQueries;
 pub use namada_token::masp::{utils, *};
 use namada_tx::event::{MaspEvent, MaspEventKind, MaspTxRef};
 use namada_tx::{IndexedTx, Tx};
-pub use utilities::{IndexerMaspClient, LedgerMaspClient};
+pub use utilities::{
+    IndexerMaspClient, LedgerMaspClient, LinearBackoffSleepMaspClient,
+};
 
 use crate::error::{Error, QueryError};
 use crate::rpc::{


### PR DESCRIPTION
## Describe your changes

Add backoff sleep between MASP indexer client failed requests.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
