### PR TITLE
Fix Typos in Documentation and Comments

### DIFF
--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -3474,7 +3474,7 @@ mod test_finalize_block {
         let code = event[1].read_attribute::<CodeAttr>().expect("Test failed");
         assert_eq!(code, ResultCode::Ok);
 
-        // This hash must be present as succesfully added by the second
+        // This hash must be present as successfully added by the second
         // transaction
     }
 

--- a/crates/tests/fixtures/README.md
+++ b/crates/tests/fixtures/README.md
@@ -1,6 +1,6 @@
 # Test fixtures
 
-Folder contaning tests fixture.
+Folder containing tests fixture.
 
 ## txs.json
 

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -565,7 +565,7 @@ pub fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
             Hash::from_str(hash_str).unwrap().to_string().to_lowercase()
         })
         .collect();
-    // Replace the targetted old hashes
+    // Replace the targeted old hashes
     for (old_code_hash, name, code) in WASM_UPDATES {
         let old_code_hash = Hash::from_str(old_code_hash).unwrap();
         let new_code_hash = Hash(*Sha256::digest(code).as_ref());


### PR DESCRIPTION


---


**Description:**  
This pull request corrects several minor typos in documentation and code comments across the project:

- Fixed "succesfully" → "successfully" in `finalize_block.rs`
- Fixed "contaning" → "containing" in test fixtures README
- Fixed "targetted" → "targeted" in `make-db-migration.rs`


