### PR TITLE
Conditionally skip fee checks in masp txs

### DIFF
--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -1246,7 +1246,7 @@ pub async fn submit_shielded_transfer(
     )
     .await?;
     let (mut tx, signing_data) =
-        args.clone().build(namada, &mut bparams).await?;
+        args.clone().build(namada, &mut bparams, false).await?;
     let disposable_fee_payer = match signing_data.fee_payer {
         either::Either::Left((_, disposable_fee_payer)) => disposable_fee_payer,
         either::Either::Right(_) => unreachable!(),
@@ -1409,7 +1409,7 @@ pub async fn submit_unshielding_transfer(
     )
     .await?;
     let (mut tx, signing_data) =
-        args.clone().build(namada, &mut bparams).await?;
+        args.clone().build(namada, &mut bparams, false).await?;
     let disposable_fee_payer = match signing_data.fee_payer {
         either::Either::Left((_, disposable_fee_payer)) => disposable_fee_payer,
         either::Either::Right(_) => unreachable!(),
@@ -1493,7 +1493,7 @@ where
     // If transaction building fails for any reason, then abort the process
     // blaming MASP build parameter generation if that had also failed.
     let (mut tx, signing_data, _) = args
-        .build(namada, &mut bparams)
+        .build(namada, &mut bparams, false)
         .await
         .map_err(|e| bparams_err.unwrap_or(e))?;
     let disposable_fee_payer = match signing_data.fee_payer {

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -361,8 +361,10 @@ impl TxShieldedTransfer {
         &mut self,
         context: &impl Namada,
         bparams: &mut impl BuildParams,
+        skip_fee_handling: bool,
     ) -> crate::error::Result<(namada_tx::Tx, SigningTxData)> {
-        tx::build_shielded_transfer(context, self, bparams).await
+        tx::build_shielded_transfer(context, self, bparams, skip_fee_handling)
+            .await
     }
 }
 
@@ -457,8 +459,15 @@ impl TxUnshieldingTransfer {
         &mut self,
         context: &impl Namada,
         bparams: &mut impl BuildParams,
+        skip_fee_handling: bool,
     ) -> crate::error::Result<(namada_tx::Tx, SigningTxData)> {
-        tx::build_unshielding_transfer(context, self, bparams).await
+        tx::build_unshielding_transfer(
+            context,
+            self,
+            bparams,
+            skip_fee_handling,
+        )
+        .await
     }
 }
 
@@ -926,9 +935,10 @@ impl TxIbcTransfer {
         &self,
         context: &impl Namada,
         bparams: &mut impl BuildParams,
+        skip_fee_handling: bool,
     ) -> crate::error::Result<(namada_tx::Tx, SigningTxData, Option<MaspEpoch>)>
     {
-        tx::build_ibc_transfer(context, self, bparams).await
+        tx::build_ibc_transfer(context, self, bparams, skip_fee_handling).await
     }
 }
 

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2706,6 +2706,7 @@ pub async fn build_ibc_transfer(
     context: &impl Namada,
     args: &args::TxIbcTransfer,
     bparams: &mut impl BuildParams,
+    skip_fee_handling: bool,
 ) -> Result<(Tx, SigningTxData, Option<MaspEpoch>)> {
     if args.ibc_shielding_data.is_some() && args.ibc_memo.is_some() {
         return Err(Error::Other(
@@ -2798,25 +2799,33 @@ pub async fn build_ibc_transfer(
     let mut transfer = token::Transfer::default();
 
     // Add masp fee payment if necessary
-    let masp_fee_data = get_masp_fee_payment_amount(
-        context,
-        &args.tx,
-        fee_per_gas_unit,
-        // If no custom gas spending key is provided default to the source
-        fee_payer,
-        args.gas_spending_key.or(args.source.spending_key()),
-    )
-    .await?;
-    if let Some(fee_data) = &masp_fee_data {
-        transfer = transfer
-            .transfer(
-                MASP,
-                fee_data.target.to_owned(),
-                fee_data.token.to_owned(),
-                fee_data.amount,
-            )
-            .ok_or(Error::Other("Combined transfer overflows".to_string()))?;
-    }
+    let masp_fee_data = if skip_fee_handling {
+        None
+    } else {
+        let masp_fee_data = get_masp_fee_payment_amount(
+            context,
+            &args.tx,
+            fee_per_gas_unit,
+            // If no custom gas spending key is provided default to the source
+            fee_payer,
+            args.gas_spending_key.or(args.source.spending_key()),
+        )
+        .await?;
+        if let Some(fee_data) = &masp_fee_data {
+            transfer = transfer
+                .transfer(
+                    MASP,
+                    fee_data.target.to_owned(),
+                    fee_data.token.to_owned(),
+                    fee_data.amount,
+                )
+                .ok_or(Error::Other(
+                    "Combined transfer overflows".to_string(),
+                ))?;
+        }
+
+        masp_fee_data
+    };
 
     // For transfer from a spending key
     let shielded_parts = construct_shielded_parts(
@@ -3235,6 +3244,7 @@ pub async fn build_shielded_transfer<N: Namada>(
     context: &N,
     args: &mut args::TxShieldedTransfer,
     bparams: &mut impl BuildParams,
+    skip_fee_handling: bool,
 ) -> Result<(Tx, SigningTxData)> {
     let mut signing_data = signing::aux_signing_data(
         context,
@@ -3290,29 +3300,37 @@ pub async fn build_shielded_transfer<N: Namada>(
     // Construct the tx data with a placeholder shielded section hash
     let mut data = token::Transfer::default();
 
-    let fee_payer = signing_data.fee_payer_or_err()?;
-    // Add masp fee payment if necessary
-    let masp_fee_data = get_masp_fee_payment_amount(
-        context,
-        &args.tx,
-        fee_per_gas_unit,
-        fee_payer,
-        // If no custom gas spending key is provided default to the first
-        // source
-        args.gas_spending_key
-            .or(args.sources.first().map(|data| data.source)),
-    )
-    .await?;
-    if let Some(fee_data) = &masp_fee_data {
-        data = data
-            .transfer(
-                MASP,
-                fee_data.target.to_owned(),
-                fee_data.token.to_owned(),
-                fee_data.amount,
-            )
-            .ok_or(Error::Other("Combined transfer overflows".to_string()))?;
-    }
+    let masp_fee_data = if skip_fee_handling {
+        None
+    } else {
+        let fee_payer = signing_data.fee_payer_or_err()?;
+        // Add masp fee payment if necessary
+        let masp_fee_data = get_masp_fee_payment_amount(
+            context,
+            &args.tx,
+            fee_per_gas_unit,
+            fee_payer,
+            // If no custom gas spending key is provided default to the first
+            // source
+            args.gas_spending_key
+                .or(args.sources.first().map(|data| data.source)),
+        )
+        .await?;
+        if let Some(fee_data) = &masp_fee_data {
+            data = data
+                .transfer(
+                    MASP,
+                    fee_data.target.to_owned(),
+                    fee_data.token.to_owned(),
+                    fee_data.amount,
+                )
+                .ok_or(Error::Other(
+                    "Combined transfer overflows".to_string(),
+                ))?;
+        }
+
+        masp_fee_data
+    };
 
     let shielded_parts = construct_shielded_parts(
         context,
@@ -3566,6 +3584,7 @@ pub async fn build_unshielding_transfer<N: Namada>(
     context: &N,
     args: &mut args::TxUnshieldingTransfer,
     bparams: &mut impl BuildParams,
+    skip_fee_handling: bool,
 ) -> Result<(Tx, SigningTxData)> {
     let mut signing_data = signing::aux_signing_data(
         context,
@@ -3628,28 +3647,36 @@ pub async fn build_unshielding_transfer<N: Namada>(
     }
 
     // Add masp fee payment if necessary
-    let fee_payer = signing_data.fee_payer_or_err()?;
-    let masp_fee_data = get_masp_fee_payment_amount(
-        context,
-        &args.tx,
-        fee_per_gas_unit,
-        fee_payer,
-        // If no custom gas spending key is provided default to the source
-        args.gas_spending_key
-            .or(args.sources.first().map(|x| x.source)),
-    )
-    .await?;
-    if let Some(fee_data) = &masp_fee_data {
-        // Add another unshield to the list
-        data = data
-            .transfer(
-                MASP,
-                fee_data.target.to_owned(),
-                fee_data.token.to_owned(),
-                fee_data.amount,
-            )
-            .ok_or(Error::Other("Combined transfer overflows".to_string()))?;
-    }
+    let masp_fee_data = if skip_fee_handling {
+        None
+    } else {
+        let fee_payer = signing_data.fee_payer_or_err()?;
+        let masp_fee_data = get_masp_fee_payment_amount(
+            context,
+            &args.tx,
+            fee_per_gas_unit,
+            fee_payer,
+            // If no custom gas spending key is provided default to the source
+            args.gas_spending_key
+                .or(args.sources.first().map(|x| x.source)),
+        )
+        .await?;
+        if let Some(fee_data) = &masp_fee_data {
+            // Add another unshield to the list
+            data = data
+                .transfer(
+                    MASP,
+                    fee_data.target.to_owned(),
+                    fee_data.token.to_owned(),
+                    fee_data.amount,
+                )
+                .ok_or(Error::Other(
+                    "Combined transfer overflows".to_string(),
+                ))?;
+        }
+
+        masp_fee_data
+    };
 
     let shielded_parts = construct_shielded_parts(
         context,


### PR DESCRIPTION
## Describe your changes

Adds a flag in the SDK builders to conditionally skip fee checks when doing MASP fee payment. This is a temporary solution to allow building masp batches where only the first tx pay fees. A better approach will require addressing #3901 and #3883 first

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
