### PR TITLE
fix: remove redundant insertion in compute_modified_redelegation func…

### DIFF
--- a/crates/proof_of_stake/src/lib.rs
+++ b/crates/proof_of_stake/src/lib.rs
@@ -1126,18 +1126,7 @@ where
                 bonds_to_remove.new_entry
             {
                 modified_redelegation.validator_to_modify = Some(src_validator);
-                modified_redelegation.epochs_to_remove = {
-                    let mut epochs = bonds_to_remove.epochs;
-                    // TODO: remove this insertion then we don't have to remove
-                    // it again in `fn update_redelegated_bonds`
-                    // when `epoch_to_modify` is Some (and avoid
-                    // `modified_redelegation.epochs_to_remove.clone`)
-                    // It affects assumption 3. in `fn
-                    // compute_new_redelegated_unbonds`, but that also looks
-                    // trivial to change.
-                    epochs.insert(bond_epoch);
-                    epochs
-                };
+                modified_redelegation.epochs_to_remove = bonds_to_remove.epochs;
                 modified_redelegation.epoch_to_modify = Some(bond_epoch);
                 modified_redelegation.new_amount = Some(new_bond_amount);
             } else {


### PR DESCRIPTION


## Describe your changes

Remove unnecessary insertion of bond_epoch into epochs set that was marked with a TODO comment. This operation was redundant as the value was later removed in the update_redelegated_bonds function. This optimization improves performance by eliminating unnecessary operations with sets in a critical path related to token delegation processing.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
