### PR TITLE
CI: bump maint version libs-v0.251 and apps-201.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,9 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MINOR_VERSION_RELEASE: "0.150.999" # bump on a major release
-  BACKPORT_LIBS_LABEL: "backport-libs-0.150" # also bump on major release
-  MAINT_LIBS_BRANCH: "maint-libs-0.150" # also bump on major release
+  MINOR_VERSION_RELEASE: "0.251.999" # bump on a major release
+  BACKPORT_LIBS_LABEL: "backport-libs-0.251" # also bump on major release
+  MAINT_LIBS_BRANCH: "maint-libs-0.251" # also bump on major release
 
 jobs:
   # Check if a PR has no major breaking changes to be backported to library

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,19 +10,19 @@ queue_rules:
     merge_method: merge
     autosquash: true   
 
-  - name: backport-apps-101.1-queue
+  - name: backport-apps-201.0-queue
     batch_size: 3
     queue_conditions:
       - "#approved-reviews-by >= 1"
-      - base = maint-101.1
+      - base = maint-201.0
     merge_method: merge
     autosquash: true   
 
-  - name: backport-libs-0.150-queue
+  - name: backport-libs-0.251-queue
     batch_size: 3
     queue_conditions:
       - "#approved-reviews-by >= 1"
-      - base = maint-libs-0.150
+      - base = maint-libs-0.251
     merge_method: merge
     autosquash: true   
 
@@ -34,8 +34,8 @@ pull_request_rules:
       - "#approved-reviews-by >= 1"
       - or:
         - base = main
-        - base = maint-101.1
-        - base = maint-libs-0.150
+        - base = maint-201.0
+        - base = maint-libs-0.251
     actions:
       queue:
 
@@ -52,18 +52,18 @@ pull_request_rules:
           Sorry about that, but you can requeue the PR by using `@mergifyio requeue`
           if you think this was a mistake.
 
-  - name: backport PR to apps 101.1 lane
+  - name: backport PR to apps 201.0 lane
     conditions:
-      - label = backport-101.1
+      - label = backport-201.0
     actions:
       backport:
         branches:
-          - "maint-101.1"
+          - "maint-201.0"
 
-  - name: backport PR to libs 0.150 lane
+  - name: backport PR to libs 0.251 lane
     conditions:
-      - label = backport-libs-0.150
+      - label = backport-libs-0.251
     actions:
       backport:
         branches:
-          - "maint-libs-0.150"
+          - "maint-libs-0.251"


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
