### PR TITLE
The MASP conversions query now requires a MASP epoch to be specified.

### DIFF
--- a/.changelog/unreleased/improvements/4776-query-conversions-requires-masp-epoch.md
+++ b/.changelog/unreleased/improvements/4776-query-conversions-requires-masp-epoch.md
@@ -1,0 +1,12 @@
+- Querying the conversion state becomes more difficult as nodes progress
+  to higher and higher epochs. For instance, on a mainnet clone running on
+  accelerated epochs, client queries for conversions always timeout (even after
+  modifying timeout_broadcast_tx_commit) when the node goes beyond a certain
+  MASP epoch. This happens because the conversion state grows linearly with
+  the MASP epoch counter. This PR attempts to address this problem by making
+  the conversions RPC endpoint require that clients specify the MASP epoch
+  they want conversions from. This implies two things: first the size of the
+  response from the conversions RPC endpoint should now be constant (equal to
+  the number of tokens in the shielded rewards program), and second a client
+  requiring all conversions now has to do a separate query for each MASP epoch.
+  ([\#4776](https://github.com/namada-net/namada/pull/4776))

--- a/crates/apps_lib/src/client/masp.rs
+++ b/crates/apps_lib/src/client/masp.rs
@@ -122,8 +122,9 @@ pub async fn syncing<
         // tests only as the cli wallet is not supposed to compile the
         // history of shielded transactions
         shielded.load_confirmed().await;
+        let masp_epoch = namada_sdk::rpc::query_masp_epoch(&client).await?;
         for (asset_type, (token, denom, position, epoch, _conv)) in
-            namada_sdk::rpc::query_conversions(&client).await?
+            namada_sdk::rpc::query_conversions(&client, &masp_epoch).await?
         {
             let pre_asset_type = AssetData {
                 token,

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -2154,8 +2154,7 @@ pub async fn query_conversions(
     let conversion_tasks = epochs
         .iter()
         .map(|epoch| rpc::query_conversions(context.client(), epoch));
-    let task_stream = futures::stream::iter(conversion_tasks);
-    let conversions = task_stream
+    let conversions = futures::stream::iter(conversion_tasks)
         .buffer_unordered(100)
         .fold(BTreeMap::default(), async |mut acc, conversion| {
             acc.append(&mut conversion.expect("Conversion should be defined"));

--- a/crates/sdk/src/queries/shell.rs
+++ b/crates/sdk/src/queries/shell.rs
@@ -98,7 +98,7 @@ router! {SHELL,
     ( "conv" / [asset_type: AssetType] ) -> Option<Conversion> = read_conversion,
 
     // Conversion state access - read conversion
-    ( "conversions" ) -> BTreeMap<AssetType, ConversionWithoutPath> = read_conversions,
+    ( "conversions" / [masp_epoch: MaspEpoch] ) -> BTreeMap<AssetType, ConversionWithoutPath> = read_conversions,
 
     // Conversion state access - read conversion
     ( "masp_reward_tokens" ) -> Vec<MaspTokenRewardData> = masp_reward_tokens,
@@ -211,6 +211,7 @@ where
 /// Query to read the conversion state
 fn read_conversions<D, H, V, T>(
     ctx: RequestCtx<'_, D, H, V, T>,
+    masp_epoch: MaspEpoch,
 ) -> namada_storage::Result<BTreeMap<AssetType, ConversionWithoutPath>>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
@@ -222,6 +223,7 @@ where
         .conversion_state
         .assets
         .iter()
+        .filter(|&(_, asset)| (asset.epoch == masp_epoch))
         .map(|(&asset_type, asset)| {
             (
                 asset_type,

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -390,6 +390,7 @@ pub async fn query_conversion<C: namada_io::Client + Sync>(
 /// Query conversions
 pub async fn query_conversions<C: namada_io::Client + Sync>(
     client: &C,
+    masp_epoch: &MaspEpoch,
 ) -> Result<
     BTreeMap<
         AssetType,
@@ -403,7 +404,9 @@ pub async fn query_conversions<C: namada_io::Client + Sync>(
     >,
     error::Error,
 > {
-    convert_response::<C, _>(RPC.shell().read_conversions(client).await)
+    convert_response::<C, _>(
+        RPC.shell().read_conversions(client, masp_epoch).await,
+    )
 }
 
 /// Query the total rewards minted by MASP


### PR DESCRIPTION
## Describe your changes
Querying the conversion state becomes more difficult as nodes progress to higher and higher epochs. For instance, on a mainnet clone running on accelerated epochs, client queries for conversions always timeout (even after modifying `timeout_broadcast_tx_commit`) when the node goes beyond a certain MASP epoch. This happens because the conversion state grows linearly with the MASP epoch counter. This PR attempts to address this problem by making the conversions RPC endpoint require that clients specify the MASP epoch they want conversions from. This implies two things: first the size of the response from the conversions RPC endpoint should now be constant (equal to the number of tokens in the shielded rewards program), and second a client requiring all conversions now has to do a separate query for each MASP epoch.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
