### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check changelog
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -148,7 +148,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -182,7 +182,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -229,7 +229,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -281,7 +281,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -318,7 +318,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -372,7 +372,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -418,7 +418,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -480,7 +480,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -597,7 +597,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Checkout ledger-namada
         run: |
           echo "Using Namada Ledger App version: v${LEDGER_APP_VERSION}"
@@ -642,7 +642,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
         run: exit 1
       - uses: cargo-bins/cargo-binstall@main
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 50
       - name: Find branch point of the PR
@@ -41,7 +41,7 @@ jobs:
           [[ -z BRANCH_POINT ]] && echo "No branch point" && exit 1
           echo "REF=$BRANCH_POINT" >> $GITHUB_OUTPUT
       - name: Checkout libs maintenance branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.MAINT_LIBS_BRANCH }}
       - name: Copy the current folder to be the baseline for semver-checks
@@ -104,7 +104,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: checkout_repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: install_rust
         uses: dtolnay/rust-toolchain@stable
       - name: install_cargo_msrv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       image:  ghcr.io/heliaxdev/namada-ci:wasm-v2.0.0
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - run: |
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - run: |


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0