### PR TITLE
Frontend MASP fee

### DIFF
--- a/.github/workflows/scripts/e2e.json
+++ b/.github/workflows/scripts/e2e.json
@@ -1,5 +1,6 @@
 {
     "e2e::eth_bridge_tests::everything": 4,
+    "e2e::ibc_tests::frontend_sus_fee": 415,
     "e2e::ibc_tests::ibc_transfers": 414,
     "e2e::ibc_tests::ibc_nft_transfers": 224,
     "e2e::ibc_tests::pgf_over_ibc": 415,

--- a/crates/apps/Cargo.toml
+++ b/crates/apps/Cargo.toml
@@ -54,6 +54,8 @@ mainnet = ["namada_apps_lib/mainnet"]
 jemalloc = ["namada_node/jemalloc"]
 migrations = ["namada_apps_lib/migrations"]
 namada-eth-bridge = ["namada_apps_lib/namada-eth-bridge"]
+# FIXME: how to enforce this in ci?
+testing = ["namada_apps_lib/testing"]
 
 [dependencies]
 namada_apps_lib.workspace = true

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -318,7 +318,9 @@ pub mod cmds {
                 Self::parse_with_ctx(matches, TxShieldingTransfer);
             let tx_unshielding_transfer =
                 Self::parse_with_ctx(matches, TxUnshieldingTransfer);
-            let tx_ibc_transfer = Self::parse_with_ctx(matches, TxIbcTransfer);
+            let tx_ibc_transfer = Self::parse_with_ctx(matches, |cmd| {
+                TxIbcTransfer(Box::new(cmd))
+            });
             let tx_osmosis_swap = Self::parse_with_ctx(matches, |cmd| {
                 TxOsmosisSwap(Box::new(cmd))
             });
@@ -507,7 +509,7 @@ pub mod cmds {
         TxShieldedTransfer(TxShieldedTransfer),
         TxShieldingTransfer(TxShieldingTransfer),
         TxUnshieldingTransfer(TxUnshieldingTransfer),
-        TxIbcTransfer(TxIbcTransfer),
+        TxIbcTransfer(Box<TxIbcTransfer>),
         TxOsmosisSwap(Box<TxOsmosisSwap>),
         QueryResult(QueryResult),
         TxUpdateAccount(TxUpdateAccount),
@@ -4953,6 +4955,7 @@ pub mod args {
                 sources: data,
                 targets,
                 tx_code_path: self.tx_code_path.to_path_buf(),
+                frontend_sus_fee: None,
             })
         }
     }
@@ -4981,6 +4984,7 @@ pub mod args {
                 sources: data,
                 targets,
                 tx_code_path,
+                frontend_sus_fee: None,
             }
         }
 
@@ -5128,6 +5132,7 @@ pub mod args {
                 ibc_memo: self.ibc_memo,
                 gas_spending_key,
                 tx_code_path: self.tx_code_path.to_path_buf(),
+                frontend_sus_fee: None,
             })
         }
     }
@@ -5169,6 +5174,8 @@ pub mod args {
                 ibc_memo,
                 gas_spending_key,
                 tx_code_path,
+                // FIXME: is it ok to skip the frontend fee from the cli?
+                frontend_sus_fee: None,
             }
         }
 
@@ -7231,6 +7238,7 @@ pub mod args {
                         IbcShieldingTransferAsset::Address(chain_ctx.get(&addr))
                     }
                 },
+                frontend_sus_fee: None,
             })
         }
     }
@@ -7266,6 +7274,7 @@ pub mod args {
                     channel_id,
                     token,
                 },
+                frontend_sus_fee: None,
             }
         }
 

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -5174,7 +5174,6 @@ pub mod args {
                 ibc_memo,
                 gas_spending_key,
                 tx_code_path,
-                // FIXME: is it ok to skip the frontend fee from the cli?
                 frontend_sus_fee: None,
             }
         }
@@ -5251,6 +5250,7 @@ pub mod args {
                 route: self.route,
                 osmosis_lcd_rpc: self.osmosis_lcd_rpc,
                 osmosis_sqs_rpc: self.osmosis_sqs_rpc,
+                frontend_sus_fee: None,
             })
         }
     }
@@ -5303,6 +5303,7 @@ pub mod args {
                 route,
                 osmosis_lcd_rpc,
                 osmosis_sqs_rpc,
+                frontend_sus_fee: None,
             }
         }
 

--- a/crates/apps_lib/src/cli/client.rs
+++ b/crates/apps_lib/src/cli/client.rs
@@ -101,7 +101,8 @@ impl CliApi {
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_unshielding_transfer(&namada, args).await?;
                     }
-                    Sub::TxIbcTransfer(TxIbcTransfer(args)) => {
+                    Sub::TxIbcTransfer(args) => {
+                        let TxIbcTransfer(args) = *args;
                         let chain_ctx = ctx.borrow_mut_chain_or_exit();
                         let ledger_address =
                             chain_ctx.get(&args.tx.ledger_address);

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -556,7 +556,7 @@ pub struct TxOsmosisSwap<C: NamadaTypes = SdkTypes> {
     /// NOTE: if the swap is shielded (from MASP to MASP), no sustainability
     /// fee should be taken
     // FIXME: try to join this with recipient
-    pub frontend_sus_fee: Option<TxTransparentTarget<C>>,
+    pub frontend_sus_fee: Option<(C::TransferTarget, InputAmount)>,
 }
 
 impl TxOsmosisSwap<SdkTypes> {
@@ -841,6 +841,7 @@ pub struct TxIbcTransfer<C: NamadaTypes = SdkTypes> {
     // FIXME: this should probably be an either with ibc_shielding_data. Yes
     // but there would still be the room for errors, maybe need marker traits?
     // Not sure...
+    // FIXME: support this in the client for testing only
     pub frontend_sus_fee: Option<TxTransparentTarget<C>>,
     /// Path to the TX WASM code file
     pub tx_code_path: PathBuf,
@@ -3263,10 +3264,12 @@ pub struct GenIbcShieldingTransfer<C: NamadaTypes = SdkTypes> {
     pub expiration: TxExpiration,
     /// Asset to shield over IBC to Namada
     pub asset: IbcShieldingTransferAsset<C>,
-    /// The optional data for the frontend sustainability fee
+    /// The optional data for the frontend sustainability fee (the target and
+    /// the amount, the token must be the same as the one involved in the
+    /// shielding transaction since ics-20 only supports a single asset)
     /// NOTE: if the shielding operation is part of a swap, and this is
     /// shielded (from MASP to MASP), no sustainability fee should be taken
-    pub frontend_sus_fee: Option<TxTransparentTarget<C>>,
+    pub frontend_sus_fee: Option<(C::TransferTarget, InputAmount)>,
 }
 
 /// IBC shielding transfer asset, to be used by [`GenIbcShieldingTransfer`]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -191,12 +191,14 @@ pub trait Namada: NamadaIo {
         &self,
         targets: Vec<args::TxShieldedTarget>,
         sources: Vec<args::TxTransparentSource>,
+        frontend_sus_fee: Option<args::TxTransparentTarget>,
     ) -> args::TxShieldingTransfer {
         args::TxShieldingTransfer {
             sources,
             targets,
             tx_code_path: PathBuf::from(TX_TRANSFER_WASM),
             tx: self.tx_builder(),
+            frontend_sus_fee,
         }
     }
 
@@ -301,6 +303,7 @@ pub trait Namada: NamadaIo {
         token: Address,
         amount: InputAmount,
         channel_id: ChannelId,
+        frontend_sus_fee: Option<args::TxTransparentTarget>,
     ) -> args::TxIbcTransfer {
         args::TxIbcTransfer {
             source,
@@ -317,6 +320,7 @@ pub trait Namada: NamadaIo {
             gas_spending_key: Default::default(),
             tx: self.tx_builder(),
             tx_code_path: PathBuf::from(TX_IBC_WASM),
+            frontend_sus_fee,
         }
     }
 

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2827,6 +2827,7 @@ pub async fn build_ibc_transfer(
         masp_fee_data
     };
 
+    // FIXME: adjust this
     if let Some(TxTransparentTarget {
         target,
         token,
@@ -3473,7 +3474,6 @@ async fn get_masp_fee_payment_amount<N: Namada>(
 }
 
 /// Build a shielding transfer
-// FIXME: need to test the fee
 pub async fn build_shielding_transfer<N: Namada>(
     context: &N,
     args: &mut args::TxShieldingTransfer,
@@ -3512,11 +3512,14 @@ pub async fn build_shielding_transfer<N: Namada>(
 
     let mut transfer_data = MaspTransferData::default();
     let mut data = token::Transfer::default();
-    for TxTransparentSource {
-        source,
-        token,
-        amount,
-    } in &args.sources
+    for (
+        id,
+        TxTransparentSource {
+            source,
+            token,
+            amount,
+        },
+    ) in args.sources.iter().enumerate()
     {
         // Validate the amount given
         let validated_amount =
@@ -3544,10 +3547,53 @@ pub async fn build_shielding_transfer<N: Namada>(
             .await?;
         }
 
+        // The frontend sustainability fee (when provided) must be paid by the
+        // first source
+        let masp_shield_amount = match (id, &args.frontend_sus_fee) {
+            (
+                0,
+                Some(TxTransparentTarget {
+                    target: sus_fee_target,
+                    token: sus_fee_token,
+                    amount: sus_fee_amt,
+                }),
+            ) => {
+                if sus_fee_token != token {
+                    return Err(Error::Other(
+                        "The sustainability fee token does not match the \
+                         token of the first transaction's source"
+                            .to_string(),
+                    ));
+                }
+
+                // Validate the amount given
+                let validated_fee_amount = validate_amount(
+                    context,
+                    sus_fee_amt.to_owned(),
+                    sus_fee_token,
+                    args.tx.force,
+                )
+                .await?;
+
+                data = data
+                    .credit(
+                        sus_fee_target.to_owned(),
+                        sus_fee_token.to_owned(),
+                        validated_fee_amount,
+                    )
+                    .ok_or(Error::Other(
+                        "Combined transfer overflows".to_string(),
+                    ))?;
+
+                checked!(validated_amount - validated_fee_amount)?
+            }
+            _ => validated_amount,
+        };
+
         transfer_data.sources.push((
             TransferSource::Address(source.to_owned()),
             token.to_owned(),
-            validated_amount,
+            masp_shield_amount,
         ));
 
         data = data
@@ -3573,22 +3619,6 @@ pub async fn build_shielding_transfer<N: Namada>(
 
         data = data
             .credit(MASP, token.to_owned(), validated_amount)
-            .ok_or(Error::Other("Combined transfer overflows".to_string()))?;
-    }
-
-    if let Some(TxTransparentTarget {
-        target,
-        token,
-        amount,
-    }) = &args.frontend_sus_fee
-    {
-        // Validate the amount given
-        let validated_amount =
-            validate_amount(context, amount.to_owned(), token, args.tx.force)
-                .await?;
-
-        data = data
-            .credit(target.to_owned(), token.to_owned(), validated_amount)
             .ok_or(Error::Other("Combined transfer overflows".to_string()))?;
     }
 
@@ -4217,6 +4247,7 @@ pub async fn gen_ibc_shielding_transfer<N: Namada>(
         .precompute_asset_types(context.client(), tokens)
         .await;
 
+    // FIXME: need to adjust this
     let extra_target = match &args.frontend_sus_fee {
         Some(TxTransparentTarget {
             target,

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -146,6 +146,7 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
     wait_for_packet_relay(
         &hermes_dir,
@@ -224,6 +225,7 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
     wait_for_packet_relay(
         &hermes_dir,
@@ -254,6 +256,7 @@ fn ibc_transfers() -> Result<()> {
         100,
         &port_id_namada,
         &channel_id_namada,
+        None,
     )?;
     transfer_from_cosmos(
         &test_gaia,
@@ -305,6 +308,7 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         true,
+        None,
     )?;
     wait_for_packet_relay(
         &hermes_dir,
@@ -324,6 +328,7 @@ fn ibc_transfers() -> Result<()> {
         1,
         &port_id_namada,
         &channel_id_namada,
+        None,
     )?;
     transfer_from_cosmos(
         &test_gaia,
@@ -358,6 +363,7 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
     wait_for_packet_relay(
         &hermes_dir,
@@ -387,6 +393,7 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
     // wait for the timeout
     sleep(10);
@@ -420,6 +427,7 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         true,
+        None,
     )?;
     wait_for_packet_relay(
         &hermes_dir,
@@ -451,6 +459,7 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         true,
+        None,
     )?;
     // wait for the timeout
     sleep(10);
@@ -506,6 +515,7 @@ fn ibc_transfers() -> Result<()> {
         100,
         &port_id_namada,
         &channel_id_namada,
+        None,
     )?;
     transfer_from_cosmos(
         &test_gaia,
@@ -610,6 +620,7 @@ fn ibc_nft_transfers() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
     clear_packet(&hermes_dir, &port_id_namada, &channel_id_namada, &test)?;
     check_balance(&test, &namada_receiver, &ibc_trace_on_namada, 0)?;
@@ -623,6 +634,7 @@ fn ibc_nft_transfers() -> Result<()> {
         1,
         &port_id_namada,
         &channel_id_namada,
+        None,
     )?;
     nft_transfer_from_cosmos(
         &test_cosmwasm,
@@ -672,6 +684,7 @@ fn ibc_nft_transfers() -> Result<()> {
         None,
         None,
         true,
+        None,
     )?;
     clear_packet(&hermes_dir, &port_id_namada, &channel_id_namada, &test)?;
     check_shielded_balance(&test, AB_VIEWING_KEY, &ibc_trace_on_namada, 0)?;
@@ -959,6 +972,7 @@ fn ibc_token_inflation() -> Result<()> {
         1,
         &port_id_namada,
         &channel_id_namada,
+        None,
     )?;
     transfer_from_cosmos(
         &test_gaia,
@@ -1150,6 +1164,7 @@ fn ibc_rate_limit() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
 
     // Transfer 1 NAM from Namada to Gaia again will fail
@@ -1170,6 +1185,7 @@ fn ibc_rate_limit() -> Result<()> {
         ),
         None,
         false,
+        None,
     )?;
 
     // wait for the next epoch
@@ -1194,6 +1210,7 @@ fn ibc_rate_limit() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
 
     // wait for the next epoch
@@ -1304,6 +1321,7 @@ fn ibc_unlimited_channel() -> Result<()> {
         ),
         None,
         false,
+        None,
     )?;
 
     // Proposal on Namada
@@ -1362,6 +1380,7 @@ fn ibc_unlimited_channel() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
     wait_for_packet_relay(
         &hermes_dir,
@@ -1630,6 +1649,7 @@ fn ibc_pfm_happy_flows() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
 
     wait_for_packet_relay(
@@ -1927,6 +1947,7 @@ fn ibc_pfm_unhappy_flows() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
 
     wait_for_packet_relay(
@@ -2251,6 +2272,7 @@ fn ibc_shielded_recv_middleware_happy_flow() -> Result<()> {
             8,
             &port_id_namada,
             &channel_id_namada,
+            None,
         )?;
         let masp_receiver = match iter {
             // Test addresses encoded using `bech32m`...
@@ -2290,6 +2312,7 @@ fn ibc_shielded_recv_middleware_happy_flow() -> Result<()> {
             None,
             Some(&memo),
             true,
+            None,
         )?;
         wait_for_packet_relay(
             &hermes_dir,
@@ -2356,6 +2379,7 @@ fn ibc_shielded_recv_middleware_unhappy_flow() -> Result<()> {
         8,
         &port_id_namada,
         &channel_id_namada,
+        None,
     )?;
     let memo = packet_forward_memo(
         MASP.to_string().into(),
@@ -2382,6 +2406,7 @@ fn ibc_shielded_recv_middleware_unhappy_flow() -> Result<()> {
         None,
         Some(&memo),
         false,
+        None,
     )?;
     wait_for_packet_relay(&hermes_dir, &port_id_gaia, &channel_id_gaia, &test)?;
 
@@ -2640,6 +2665,7 @@ fn try_invalid_transfers(
         Some(&format!("Invalid IBC denom: {nam_addr}")),
         None,
         false,
+        None,
     )?;
 
     // invalid channel
@@ -2657,6 +2683,7 @@ fn try_invalid_transfers(
         Some("No channel end: port transfer, channel channel-42"),
         None,
         false,
+        None,
     )?;
 
     Ok(())
@@ -2713,6 +2740,7 @@ fn transfer(
     expected_err: Option<&str>,
     ibc_memo: Option<&str>,
     gen_refund_target: bool,
+    frontend_sus_fee: Option<&str>,
 ) -> Result<u32> {
     let rpc = get_actor_rpc(test, Who::Validator(0));
 
@@ -2778,6 +2806,11 @@ fn transfer(
         cmd.assert_success();
         tx_args.push("--refund-target");
         tx_args.push(IBC_REFUND_TARGET_ALIAS);
+    }
+
+    if let Some(target) = frontend_sus_fee {
+        tx_args.push("--frontend-sus-fee");
+        tx_args.push(target.as_ref());
     }
 
     let mut client = run!(test, Bin::Client, tx_args, Some(300))?;
@@ -3401,12 +3434,13 @@ fn gen_ibc_shielding_data(
     amount: u64,
     port_id: &PortId,
     channel_id: &ChannelId,
+    frontend_sus_fee: Option<&str>,
 ) -> Result<PathBuf> {
     let rpc = get_actor_rpc(dst_test, Who::Validator(0));
     let output_folder = dst_test.test_dir.path().to_string_lossy();
 
     let amount = amount.to_string();
-    let args = vec![
+    let mut args = vec![
         "ibc-gen-shielding",
         "--output-folder-path",
         &output_folder,
@@ -3423,6 +3457,10 @@ fn gen_ibc_shielding_data(
         "--node",
         &rpc,
     ];
+    if let Some(target) = frontend_sus_fee {
+        args.push("--frontend-sus-fee-ibc");
+        args.push(target.as_ref());
+    }
 
     let mut client = run!(dst_test, Bin::Client, args, Some(120))?;
     let (_unread, matched) =
@@ -3744,6 +3782,108 @@ fn nft_transfer_from_cosmos(
     Ok(())
 }
 
+// Verify that MASP frontend fees can be paid also when doing IBC transactions,
+// specifically an unshielding originating from Namada and a shielding tx
+// originating from a foreign chain
+#[test]
+fn frontend_sus_fee() -> Result<()> {
+    let update_genesis =
+        |mut genesis: templates::All<templates::Unvalidated>, base_dir: &_| {
+            genesis.parameters.parameters.epochs_per_year =
+                epochs_per_year_from_min_duration(1800);
+            genesis.parameters.ibc_params.default_mint_limit =
+                Amount::max_signed();
+            genesis
+                .parameters
+                .ibc_params
+                .default_per_epoch_throughput_limit = Amount::max_signed();
+            setup::set_validators(1, genesis, base_dir, |_| 0, vec![])
+        };
+    let (ledger, gaia, test, test_gaia) =
+        run_namada_cosmos(CosmosChainType::Gaia(None), update_genesis)?;
+    let _bg_ledger = ledger.background();
+    let _bg_gaia = gaia.background();
+
+    let hermes_dir = setup_hermes(&test, &test_gaia)?;
+    let port_id_namada = FT_PORT_ID.parse().unwrap();
+    let port_id_gaia = FT_PORT_ID.parse().unwrap();
+    let (channel_id_namada, channel_id_gaia) = create_channel_with_hermes(
+        &hermes_dir,
+        &test,
+        &test_gaia,
+        &port_id_namada,
+        &port_id_gaia,
+    )?;
+
+    // Start relaying
+    let hermes = run_hermes(&hermes_dir)?;
+    let _bg_hermes = hermes.background();
+
+    // Shielding transfer 100 samoleans from Gaia to Namada
+    let shielding_data_path = gen_ibc_shielding_data(
+        &test,
+        AA_PAYMENT_ADDRESS,
+        COSMOS_COIN,
+        100,
+        &port_id_namada,
+        &channel_id_namada,
+        Some(ESTER),
+    )?;
+    transfer_from_cosmos(
+        &test_gaia,
+        COSMOS_USER,
+        MASP.to_string(),
+        COSMOS_COIN,
+        100,
+        &port_id_gaia,
+        &channel_id_gaia,
+        Some(Either::Left(shielding_data_path)),
+        None,
+    )?;
+    wait_for_packet_relay(
+        &hermes_dir,
+        &port_id_gaia,
+        &channel_id_gaia,
+        &test_gaia,
+    )?;
+    // Check the token on Namada
+    let ibc_denom_on_namada =
+        format!("{port_id_namada}/{channel_id_namada}/{COSMOS_COIN}");
+    check_shielded_balance(&test, AA_VIEWING_KEY, &ibc_denom_on_namada, 100)?;
+    check_cosmos_balance(&test_gaia, COSMOS_USER, COSMOS_COIN, 800)?;
+    check_balance(&test, ESTER, &ibc_denom_on_namada, 1)?;
+
+    // Unshielding transfer 10 samoleans from Namada to Gaia
+    let gaia_receiver = find_cosmos_address(&test_gaia, COSMOS_USER)?;
+    transfer(
+        &test,
+        B_SPENDING_KEY,
+        &gaia_receiver,
+        &ibc_denom_on_namada,
+        10,
+        Some(BERTHA_KEY),
+        &port_id_namada,
+        &channel_id_namada,
+        None,
+        None,
+        None,
+        None,
+        true,
+        Some(ESTER),
+    )?;
+    wait_for_packet_relay(
+        &hermes_dir,
+        &port_id_namada,
+        &channel_id_namada,
+        &test,
+    )?;
+    check_shielded_balance(&test, AB_VIEWING_KEY, &ibc_denom_on_namada, 40)?;
+    check_cosmos_balance(&test_gaia, COSMOS_USER, COSMOS_COIN, 810)?;
+    check_balance(&test, ESTER, &ibc_denom_on_namada, 1)?;
+
+    Ok(())
+}
+
 /// Basic Osmosis test that checks if the chain has been set up correctly.
 #[test]
 fn osmosis_basic() -> Result<()> {
@@ -3867,6 +4007,7 @@ fn osmosis_xcs() -> Result<()> {
         None,
         None,
         false,
+        None,
     )?;
     // Transfer Samoleans from Gaia
     transfer_from_cosmos(

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -9365,3 +9365,180 @@ fn multiple_inputs_from_single_note() -> Result<()> {
 
     Ok(())
 }
+
+// Test that shielding and unshielding transactions can pay a small fee to a
+// transparent address as a form of sustainability fee for frontend providers
+#[test]
+fn frontend_sus_fee() -> Result<()> {
+    // This address doesn't matter for tests. But an argument is required.
+    let validator_one_rpc = "http://127.0.0.1:26567";
+    // Download the shielded pool parameters before starting node
+    let _ = FsShieldedUtils::new(PathBuf::new());
+    let (mut node, _services) = setup::setup()?;
+    // Wait till epoch boundary
+    node.next_masp_epoch();
+
+    // Initialize address of the frontend provider with no balance
+    let (frontend_alias, _frontend_key) =
+        make_temp_account(&node, validator_one_rpc, "Frontend", NAM, 0)?;
+
+    // Test sus fee when shielding. Send 10 NAM from Albert to PA and 1 NAM to a
+    // transparent address owned by the frontend provider
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            apply_use_device(vec![
+                "shield",
+                "--source",
+                ALBERT,
+                "--target",
+                AA_PAYMENT_ADDRESS,
+                "--token",
+                NAM,
+                "--amount",
+                "10",
+                "--frontend-sus-fee",
+                frontend_alias,
+                "--signing-keys",
+                ALBERT_KEY,
+                "--node",
+                validator_one_rpc,
+            ]),
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+
+    // Assert NAM balance at VK(A) is 10
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                NAM,
+                "--node",
+                validator_one_rpc,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains("nam: 10"));
+
+    // Assert NAM balance at the frontend is 1
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                frontend_alias,
+                "--token",
+                NAM,
+                "--node",
+                validator_one_rpc,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains("nam: 1"));
+
+    // Test sus fee when unshielding. Send 9 NAM from PA to Albert and 1 NAM to
+    // a transparent address owned by the frontend provider
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            apply_use_device(vec![
+                "unshield",
+                "--source",
+                AA_VIEWING_KEY,
+                "--target",
+                ALBERT,
+                "--token",
+                NAM,
+                "--amount",
+                "9",
+                "--frontend-sus-fee",
+                frontend_alias,
+                "--signing-keys",
+                ALBERT_KEY,
+                "--node",
+                validator_one_rpc,
+            ]),
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+
+    // Assert NAM balance at VK(A) is 0
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                NAM,
+                "--node",
+                validator_one_rpc,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains("nam: 0"));
+
+    // Assert NAM balance at the frontend is 2
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                frontend_alias,
+                "--token",
+                NAM,
+                "--node",
+                validator_one_rpc,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains("nam: 2"));
+
+    Ok(())
+}


### PR DESCRIPTION
## Describe your changes

Possible implementation of masp frontend sustainability fees. The sdk has been extended to allow specifying an extra recipient for this fee.

For operations operating originating from the Namada chain this fee is pretty much free, any token can be used.

For incoming ibc shielding operations, the actual fee payment has to be encoded in the transparent vout of the Masp bundle (since the ibc recv packet limits us to a single recipient). This is just a commitment to the actual namada address so the format of the IBC packets has been changed to include not only the masp transaction but also this ancillary data. The WASM ibc transaction has been changed to execute this extra transparent transfer. On top of this, since the ibc recv packet also limits us to a single token, the fee has to be paid in the same token which gets shielded and nft transfers do not support this frontend fee.

Alternative approach:
- Encode the fee as a shielded output of the bundle. This would still limit us to a single asset but would require no change in the protocol/wasm transaction/ibc packets. On the downside, it generates notes with possibly little amounts that might be a burden to spend from the perspective of the frontend providers (due to the gas limits)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
