### PR TITLE
Bumping version of arse merkle tree

### DIFF
--- a/.changelog/unreleased/improvements/bump-arse-merkle-tree-version-4791.md
+++ b/.changelog/unreleased/improvements/bump-arse-merkle-tree-version-4791.md
@@ -1,0 +1,3 @@
+- Uses the new published version of our sparse merkle tree that speeds up
+  validation times. This should speed up the time it takes to start a node.
+  ([\#4791](https://github.com/anoma/namada/pull/4791))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5466,9 +5466,9 @@ dependencies = [
 
 [[package]]
 name = "nam-sparse-merkle-tree"
-version = "0.3.2-nam.0"
+version = "0.3.3-nam.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae108a0f6aabf789e34d6d447c1184608d1c70c087f957b720042226a47ab63"
+checksum = "09548cb2907afb9ee1047b7bbe9601e25b73b69229fca50d49badd97cc190cfb"
 dependencies = [
  "blake2b-rs",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ arbitrary = {version = "1.4", features = ["derive"]}
 ark-bls12-381 = {version = "0.5"}
 ark-serialize = {version = "0.5"}
 ark-std = "0.5"
-arse-merkle-tree = {package = "nam-sparse-merkle-tree", version = "0.3.2-nam.0", default-features = false, features = ["std", "borsh"]}
+arse-merkle-tree = {package = "nam-sparse-merkle-tree", version = "0.3.3-nam.0", default-features = false, features = ["std", "borsh"]}
 assert_cmd = "2.0"
 assert_matches = "1.5"
 async-trait = {version = "0.1"}


### PR DESCRIPTION
## Describe your changes
Uses the new published version of our sparse merkle tree that speeds up validation times. This should speed up the time it takes to start a node.
## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
