### PR TITLE
Update wasm Cargo.lock files with new sparse merkle tree

### DIFF
--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -4359,9 +4359,9 @@ dependencies = [
 
 [[package]]
 name = "nam-sparse-merkle-tree"
-version = "0.3.2-nam.0"
+version = "0.3.3-nam.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae108a0f6aabf789e34d6d447c1184608d1c70c087f957b720042226a47ab63"
+checksum = "09548cb2907afb9ee1047b7bbe9601e25b73b69229fca50d49badd97cc190cfb"
 dependencies = [
  "borsh",
  "cfg-if",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2450,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "nam-sparse-merkle-tree"
-version = "0.3.2-nam.0"
+version = "0.3.3-nam.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae108a0f6aabf789e34d6d447c1184608d1c70c087f957b720042226a47ab63"
+checksum = "09548cb2907afb9ee1047b7bbe9601e25b73b69229fca50d49badd97cc190cfb"
 dependencies = [
  "borsh",
  "cfg-if",


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
