### PR TITLE
Change MASP zk backend to bellperson

### DIFF
--- a/.changelog/unreleased/improvements/4817-change-masp-zk-backend.md
+++ b/.changelog/unreleased/improvements/4817-change-masp-zk-backend.md
@@ -1,0 +1,3 @@
+- The masp now uses the bellperson backend to synthesize circuits and build zk
+  proofs. Benchmarking this indicates substantial speed ups in proving time.
+  ([\#4817](https://github.com/namada-net/namada/pull/4817))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -555,24 +555,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
-name = "bellman"
-version = "0.14.0"
+name = "bellpepper-core"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afceed28bac7f9f5a508bca8aeeff51cdfa4770c0b967ac55c621e2ddfd6171"
+checksum = "b2c9a1b2f748c59938bc72165ebdf34efffeecee9cfbe0bb7d6b01aea21cd523"
 dependencies = [
- "bitvec",
  "blake2s_simd",
  "byteorder",
- "crossbeam-channel",
  "ff",
- "group",
- "lazy_static",
- "log",
- "num_cpus",
- "pairing",
- "rand_core",
- "rayon",
- "subtle",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -744,7 +736,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -753,7 +745,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1239,7 +1231,7 @@ dependencies = [
  "bech32 0.9.1",
  "bs58",
  "digest 0.10.7",
- "generic-array",
+ "generic-array 0.14.7",
  "hex",
  "ripemd",
  "serde",
@@ -1671,7 +1663,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core",
  "subtle",
  "zeroize",
@@ -1683,7 +1675,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -1973,7 +1965,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2176,6 +2168,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ec-gpu"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd63582de2b59ea1aa48d7c1941b5d87618d95484397521b3acdfa0e1e9f5e45"
+
+[[package]]
+name = "ec-gpu-gen"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2353854622ec1abfd22243eb958453b95f1502e2a56648bf9db49ccbfb55f01"
+dependencies = [
+ "bitvec",
+ "crossbeam-channel",
+ "ec-gpu",
+ "execute",
+ "ff",
+ "group",
+ "hex",
+ "log",
+ "num_cpus",
+ "once_cell",
+ "rayon",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+ "yastl",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,7 +2277,7 @@ dependencies = [
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "pkcs8",
  "rand_core",
@@ -2654,7 +2674,7 @@ dependencies = [
  "const-hex",
  "elliptic-curve",
  "ethabi",
- "generic-array",
+ "generic-array 0.14.7",
  "k256",
  "num_enum",
  "once_cell",
@@ -2803,6 +2823,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "execute"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a82608ee96ce76aeab659e9b8d3c2b787bffd223199af88c674923d861ada10"
+dependencies = [
+ "execute-command-macro",
+ "execute-command-tokens",
+ "generic-array 1.2.0",
+]
+
+[[package]]
+name = "execute-command-macro"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dec53d547564e911dc4ff3ecb726a64cf41a6fa01a2370ebc0d95175dd08bd"
+dependencies = [
+ "execute-command-macro-impl",
+]
+
+[[package]]
+name = "execute-command-macro-impl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8cd46a041ad005ab9c71263f9a0ff5b529eac0fe4cc9b4a20f4f0765d8cf4b"
+dependencies = [
+ "execute-command-tokens",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "execute-command-tokens"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69dc321eb6be977f44674620ca3aa21703cb20ffbe560e1ae97da08401ffbcad"
+
+[[package]]
 name = "expectrl"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,6 +2974,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
 dependencies = [
  "paste",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3163,6 +3229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3245,7 +3320,9 @@ checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "memuse",
+ "rand",
  "rand_core",
+ "rand_xorshift",
  "subtle",
 ]
 
@@ -4551,11 +4628,11 @@ dependencies = [
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.3.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ad43a3f5795945459d577f6589cf62a476e92c79b75e70cd954364e14ce17b"
+checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
- "serde",
+ "either",
 ]
 
 [[package]]
@@ -4609,7 +4686,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -5088,24 +5165,25 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "2.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ada01979db25a366c3e7382d0693fc65571dea7dc81960ef03a00aa4bb12f3"
+checksum = "0246bfddd3de5ba4c878d52ff5d62992a7059e0a7eae010ffea6edcf47929653"
 dependencies = [
  "arbitrary",
  "borsh",
  "chacha20",
  "chacha20poly1305",
  "cipher",
+ "nam-blstrs",
  "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "masp_primitives"
-version = "2.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fc77ab4163be1a72719a6cd27f9ab1f86dc9080a3d42aa2edd41e687aa97d5"
+checksum = "961a3494f0cbd5ab32042b4f5ce4bdeb1dba148b79f60a1cfe15b121e59f1de5"
 dependencies = [
  "aes",
  "arbitrary",
@@ -5123,7 +5201,7 @@ dependencies = [
  "lazy_static",
  "masp_note_encryption",
  "memuse",
- "nam-bls12_381",
+ "nam-blstrs",
  "nam-jubjub",
  "nam-num-traits",
  "nonempty 0.11.0",
@@ -5137,22 +5215,24 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "2.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a2bf8522c7f7a6529c7c450119e3fb06c2be638894866f3ad9e5a133a5d048"
+checksum = "68de02b0e1370b9070da23ce237a240cc35a7b5928f699aa4a49363734f7eecc"
 dependencies = [
- "bellman",
  "blake2b_simd",
  "directories 5.0.1",
+ "ff",
  "getrandom 0.2.15",
  "group",
  "itertools 0.14.0",
  "lazy_static",
  "masp_primitives",
  "minreq",
- "nam-bls12_381",
+ "nam-bellperson",
+ "nam-blstrs",
  "nam-jubjub",
  "nam-redjubjub",
+ "pairing",
  "rand_core",
  "tracing",
 ]
@@ -5325,16 +5405,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
-name = "nam-bls12_381"
-version = "0.8.1-nam.0"
+name = "nam-bellperson"
+version = "0.26.2-nam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e768b0e2383163f2f4bbce1112d6454b2cb515950b0a9177733f0d71254d2c68"
+checksum = "130c55b8c2814e06aeb0d919e2aaaf8c7ef0a80cd6bdeca2d5d680e1cc382258"
 dependencies = [
- "arbitrary",
+ "bellpepper-core",
+ "bincode",
+ "blake2s_simd",
+ "byteorder",
+ "crossbeam-channel",
+ "digest 0.10.7",
+ "ec-gpu",
+ "ec-gpu-gen",
  "ff",
  "group",
+ "log",
+ "memmap2 0.5.10",
+ "nam-blstrs",
+ "pairing",
+ "rand",
+ "rand_core",
+ "rayon",
+ "rustversion",
+ "serde",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "nam-blst"
+version = "0.3.15-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1632631c6e2ff973612128336180d9002de7137df421633e7c4d7e8a2d6c3d"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "nam-blstrs"
+version = "0.7.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b31595611bdfcbe0880c411d325e6aae7bade26fcdc5dc4cc8aeec54a7db06"
+dependencies = [
+ "arbitrary",
+ "byte-slice-cast",
+ "ff",
+ "group",
+ "nam-blst",
  "pairing",
  "rand_core",
+ "serde",
  "subtle",
 ]
 
@@ -5353,15 +5478,15 @@ dependencies = [
 
 [[package]]
 name = "nam-jubjub"
-version = "0.10.1-nam.0"
+version = "1.10.1-nam.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdced0f5975d8f80cb82a84d464481acb7b586d22f447dda86947d6a572997b9"
+checksum = "7a23e14862160638c432432025599689ccd1e28c05428d8a437986240c0b89f2"
 dependencies = [
  "arbitrary",
  "bitvec",
  "ff",
  "group",
- "nam-bls12_381",
+ "nam-blstrs",
  "rand_core",
  "subtle",
 ]
@@ -6153,7 +6278,7 @@ dependencies = [
  "async-trait",
  "borsh",
  "eyre",
- "flume",
+ "flume 0.11.1",
  "futures",
  "itertools 0.14.0",
  "lazy_static",
@@ -8345,7 +8470,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "serdect",
  "subtle",
@@ -9408,6 +9533,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -11075,6 +11209,16 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yastl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca6c5a4d66c1a9ea261811cf4773c27343de7e5033e1b75ea3f297dc7db3c1a"
+dependencies = [
+ "flume 0.10.14",
+ "scopeguard",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ impl-num-traits = "0.2"
 indexmap = { package = "nam-indexmap", version = "2.7.1-nam.0", features = ["borsh-schema", "serde"] }
 init-once = "0.6"
 itertools = "0.14"
-jubjub = { package = "nam-jubjub", version = "0.10.1-nam.0" }
+jubjub = { package = "nam-jubjub", version = "1.10.1-nam.1" }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "pkcs8", "precomputed-tables", "serde", "std"]}
 kdam = "0.6"
 konst = { version = "0.3", default-features = false }
@@ -189,8 +189,8 @@ libfuzzer-sys = "0.4"
 libloading = "0.8"
 linkme = "0.3"
 madato = "0.7"
-masp_primitives = "2.0.0"
-masp_proofs = { version = "2.0.0", default-features = false, features = ["local-prover"] }
+masp_primitives = "3.0.5"
+masp_proofs = { version = "3.0.5", default-features = false, features = ["local-prover"] }
 num256 = "0.6"
 num_cpus = "1.13"
 num_enum = "0.7"

--- a/crates/benches/Cargo.toml
+++ b/crates/benches/Cargo.toml
@@ -50,7 +50,7 @@ namada_vm = { workspace = true, default-features = true }
 namada_vp.workspace = true
 
 masp_primitives.workspace = true
-masp_proofs = { workspace = true, features = ["benchmarks", "multicore"] }
+masp_proofs = { workspace = true, features = ["benchmarks"] }
 borsh.workspace = true
 criterion.workspace = true
 lazy_static.workspace = true

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -66,6 +66,7 @@ use namada_node::bench_utils::{
 use namada_vm::wasm::VpCache;
 use namada_vm::wasm::run::VpEvalWasm;
 use namada_vp::native_vp::{self, NativeVp};
+use rand::thread_rng;
 use rand_core::OsRng;
 
 type Ctx<'ctx, S, D, H, CA> =
@@ -1067,6 +1068,7 @@ fn masp_batch_signature_verification(c: &mut Criterion) {
 // cost for every proofs. Charge the full cost for the first note and then
 // charge the variable cost multiplied by the number of remaining notes
 fn masp_batch_spend_proofs_validate(c: &mut Criterion) {
+    let mut rng = thread_rng();
     let mut group = c.benchmark_group("masp_batch_spend_proofs_validate");
     let PVKs { spend_vk, .. } = preload_verifying_keys();
 
@@ -1099,7 +1101,9 @@ fn masp_batch_spend_proofs_validate(c: &mut Criterion) {
 
                     ctx
                 },
-                |ctx| assert!(ctx.verify_spend_proofs(spend_vk).is_ok()),
+                |ctx| {
+                    assert!(ctx.verify_spend_proofs(spend_vk, &mut rng).is_ok())
+                },
                 BatchSize::SmallInput,
             )
         });
@@ -1112,6 +1116,7 @@ fn masp_batch_spend_proofs_validate(c: &mut Criterion) {
 // cost for every proofs. Charge the full cost for the first note and then
 // charge the variable cost multiplied by the number of remaining notes
 fn masp_batch_convert_proofs_validate(c: &mut Criterion) {
+    let mut rng = thread_rng();
     let mut group = c.benchmark_group("masp_batch_convert_proofs_validate");
     let PVKs { convert_vk, .. } = preload_verifying_keys();
 
@@ -1144,7 +1149,11 @@ fn masp_batch_convert_proofs_validate(c: &mut Criterion) {
 
                     ctx
                 },
-                |ctx| assert!(ctx.verify_convert_proofs(convert_vk).is_ok()),
+                |ctx| {
+                    assert!(
+                        ctx.verify_convert_proofs(convert_vk, &mut rng).is_ok()
+                    )
+                },
                 BatchSize::SmallInput,
             )
         });
@@ -1159,6 +1168,7 @@ fn masp_batch_convert_proofs_validate(c: &mut Criterion) {
 fn masp_batch_output_proofs_validate(c: &mut Criterion) {
     let mut group = c.benchmark_group("masp_batch_output_proofs_validate");
     let PVKs { output_vk, .. } = preload_verifying_keys();
+    let mut rng = thread_rng();
 
     for double in [true, false] {
         let (tx_data, transaction) =
@@ -1189,7 +1199,11 @@ fn masp_batch_output_proofs_validate(c: &mut Criterion) {
 
                     ctx
                 },
-                |ctx| assert!(ctx.verify_output_proofs(output_vk).is_ok()),
+                |ctx| {
+                    assert!(
+                        ctx.verify_output_proofs(output_vk, &mut rng).is_ok()
+                    )
+                },
                 BatchSize::SmallInput,
             )
         });

--- a/crates/node/src/shell/init_chain.rs
+++ b/crates/node/src/shell/init_chain.rs
@@ -177,7 +177,7 @@ where
                 bls12_381::Scalar::from(
                     self.state.in_mem().conversion_state.tree.root(),
                 )
-                .to_bytes(),
+                .to_bytes_le(),
             ),
         )?;
 

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -20,7 +20,7 @@ mainnet = [
   "namada_events/mainnet",
   "namada_token/mainnet",
 ]
-multicore = ["masp_proofs/multicore", "namada_token/multicore"]
+multicore = ["namada_token/multicore"]
 std = ["fd-lock", "download-params", "namada_token/std", "namada_wallet/std"]
 async-send = ["namada_io/async-send"]
 namada-eth-bridge = ["namada_ethereum_bridge/namada-eth-bridge"]

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -888,7 +888,7 @@ where
         &crate::storage_key::masp_convert_anchor_key(),
         namada_core::hash::Hash(
             bls12_381::Scalar::from(storage.conversion_state().tree.root())
-                .to_bytes(),
+                .to_bytes_le(),
         ),
     )?;
 

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -316,6 +316,7 @@ pub enum ContextSyncStatus {
 
 #[cfg(test)]
 mod tests {
+    use masp_primitives::ff::Field;
     use masp_proofs::bls12_381::Bls12;
 
     use super::*;
@@ -386,7 +387,7 @@ mod tests {
             }
         }
 
-        let dummy_circuit = FakeCircuit { x: Scalar::zero() };
+        let dummy_circuit = FakeCircuit { x: Scalar::ZERO };
         let mut rng = rand::thread_rng();
         let fake_params: Parameters<Bls12> =
             generate_random_parameters(dummy_circuit, &mut rng)
@@ -439,10 +440,11 @@ pub mod testing {
     use masp_primitives::consensus::BranchId;
     use masp_primitives::consensus::testing::arb_height;
     use masp_primitives::constants::{
-        SPENDING_KEY_GENERATOR, VALUE_COMMITMENT_RANDOMNESS_GENERATOR,
+        spending_key_generator, value_commitment_randomness_generator,
     };
     use masp_primitives::ff::PrimeField;
     use masp_primitives::group::GroupEncoding;
+    use masp_primitives::group::prime::PrimeCurveAffine;
     use masp_primitives::jubjub;
     use masp_primitives::keys::OutgoingViewingKey;
     use masp_primitives::memo::MemoBytes;
@@ -561,7 +563,7 @@ pub mod testing {
             // This is the result of the re-randomization, we compute it for the
             // caller
             let rk = PublicKey(proof_generation_key.ak.into())
-                .randomize(ar, SPENDING_KEY_GENERATOR);
+                .randomize(ar, spending_key_generator());
 
             // Compute value commitment
             let value_commitment: jubjub::ExtendedPoint =
@@ -683,7 +685,7 @@ pub mod testing {
             // Grab the `bvk` using DerivePublic.
             let bvk = PublicKey::from_private(
                 &bsk,
-                VALUE_COMMITMENT_RANDOMNESS_GENERATOR,
+                value_commitment_randomness_generator(),
             );
 
             // In order to check internal consistency, let's use the accumulated
@@ -718,7 +720,7 @@ pub mod testing {
             Ok(bsk.sign(
                 &data_to_be_signed,
                 &mut *rng,
-                VALUE_COMMITMENT_RANDOMNESS_GENERATOR,
+                value_commitment_randomness_generator(),
             ))
         }
     }

--- a/crates/shielded_token/src/storage_key.rs
+++ b/crates/shielded_token/src/storage_key.rs
@@ -350,7 +350,7 @@ pub fn masp_commitment_anchor_key(anchor: impl Into<Scalar>) -> storage::Key {
     storage::Key::from(address::MASP.to_db_key())
         .push(&MASP_NOTE_COMMITMENT_ANCHOR_PREFIX.to_owned())
         .expect("Cannot obtain a storage key")
-        .push(&Hash(anchor.into().to_bytes()))
+        .push(&Hash(anchor.into().to_bytes_le()))
         .expect("Cannot obtain a storage key")
 }
 

--- a/crates/shielded_token/src/vp.rs
+++ b/crates/shielded_token/src/vp.rs
@@ -300,7 +300,7 @@ where
                 for description in &bundle.shielded_converts {
                     // Check if the provided anchor matches the current
                     // conversion tree's one
-                    if namada_core::hash::Hash(description.anchor.to_bytes())
+                    if namada_core::hash::Hash(description.anchor.to_bytes_le())
                         != expected_anchor
                     {
                         let error = Error::new_const(

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -462,19 +462,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
-name = "bellman"
-version = "0.14.0"
+name = "bellpepper-core"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afceed28bac7f9f5a508bca8aeeff51cdfa4770c0b967ac55c621e2ddfd6171"
+checksum = "b2c9a1b2f748c59938bc72165ebdf34efffeecee9cfbe0bb7d6b01aea21cd523"
 dependencies = [
- "bitvec",
  "blake2s_simd",
  "byteorder",
  "ff",
- "group",
- "pairing",
- "rand_core",
- "subtle",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -482,6 +479,15 @@ name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
@@ -607,7 +613,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -616,7 +622,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -967,7 +973,7 @@ dependencies = [
  "bech32 0.9.1",
  "bs58",
  "digest 0.10.7",
- "generic-array",
+ "generic-array 0.14.7",
  "hex",
  "ripemd",
  "serde",
@@ -1214,6 +1220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,7 +1274,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core",
  "subtle",
  "zeroize",
@@ -1271,7 +1286,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -1449,7 +1464,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1598,6 +1613,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ec-gpu"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd63582de2b59ea1aa48d7c1941b5d87618d95484397521b3acdfa0e1e9f5e45"
+
+[[package]]
+name = "ec-gpu-gen"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2353854622ec1abfd22243eb958453b95f1502e2a56648bf9db49ccbfb55f01"
+dependencies = [
+ "bitvec",
+ "crossbeam-channel",
+ "ec-gpu",
+ "execute",
+ "ff",
+ "group",
+ "hex",
+ "log",
+ "num_cpus",
+ "once_cell",
+ "rayon",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+ "yastl",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,7 +1708,7 @@ dependencies = [
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "pkcs8",
  "rand_core",
@@ -2005,7 +2048,7 @@ dependencies = [
  "const-hex",
  "elliptic-curve",
  "ethabi",
- "generic-array",
+ "generic-array 0.14.7",
  "k256",
  "num_enum",
  "once_cell",
@@ -2154,6 +2197,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "execute"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a82608ee96ce76aeab659e9b8d3c2b787bffd223199af88c674923d861ada10"
+dependencies = [
+ "execute-command-macro",
+ "execute-command-tokens",
+ "generic-array 1.2.0",
+]
+
+[[package]]
+name = "execute-command-macro"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dec53d547564e911dc4ff3ecb726a64cf41a6fa01a2370ebc0d95175dd08bd"
+dependencies = [
+ "execute-command-macro-impl",
+]
+
+[[package]]
+name = "execute-command-macro-impl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8cd46a041ad005ab9c71263f9a0ff5b529eac0fe4cc9b4a20f4f0765d8cf4b"
+dependencies = [
+ "execute-command-tokens",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "execute-command-tokens"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69dc321eb6be977f44674620ca3aa21703cb20ffbe560e1ae97da08401ffbcad"
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2324,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
 dependencies = [
  "paste",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2484,6 +2573,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,7 +2664,9 @@ checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "memuse",
+ "rand",
  "rand_core",
+ "rand_xorshift",
  "subtle",
 ]
 
@@ -3768,11 +3868,11 @@ dependencies = [
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.3.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ad43a3f5795945459d577f6589cf62a476e92c79b75e70cd954364e14ce17b"
+checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
- "serde",
+ "either",
 ]
 
 [[package]]
@@ -3826,7 +3926,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -4120,23 +4220,24 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "2.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ada01979db25a366c3e7382d0693fc65571dea7dc81960ef03a00aa4bb12f3"
+checksum = "0246bfddd3de5ba4c878d52ff5d62992a7059e0a7eae010ffea6edcf47929653"
 dependencies = [
  "borsh",
  "chacha20",
  "chacha20poly1305",
  "cipher",
+ "nam-blstrs",
  "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "masp_primitives"
-version = "2.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fc77ab4163be1a72719a6cd27f9ab1f86dc9080a3d42aa2edd41e687aa97d5"
+checksum = "961a3494f0cbd5ab32042b4f5ce4bdeb1dba148b79f60a1cfe15b121e59f1de5"
 dependencies = [
  "aes",
  "bip0039",
@@ -4153,7 +4254,7 @@ dependencies = [
  "lazy_static",
  "masp_note_encryption",
  "memuse",
- "nam-bls12_381",
+ "nam-blstrs",
  "nam-jubjub",
  "nam-num-traits",
  "nonempty 0.11.0",
@@ -4167,22 +4268,24 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "2.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a2bf8522c7f7a6529c7c450119e3fb06c2be638894866f3ad9e5a133a5d048"
+checksum = "68de02b0e1370b9070da23ce237a240cc35a7b5928f699aa4a49363734f7eecc"
 dependencies = [
- "bellman",
  "blake2b_simd",
  "directories",
+ "ff",
  "getrandom 0.2.15",
  "group",
  "itertools 0.14.0",
  "lazy_static",
  "masp_primitives",
  "minreq",
- "nam-bls12_381",
+ "nam-bellperson",
+ "nam-blstrs",
  "nam-jubjub",
  "nam-redjubjub",
+ "pairing",
  "rand_core",
  "tracing",
 ]
@@ -4309,15 +4412,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
-name = "nam-bls12_381"
-version = "0.8.1-nam.0"
+name = "nam-bellperson"
+version = "0.26.2-nam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e768b0e2383163f2f4bbce1112d6454b2cb515950b0a9177733f0d71254d2c68"
+checksum = "130c55b8c2814e06aeb0d919e2aaaf8c7ef0a80cd6bdeca2d5d680e1cc382258"
 dependencies = [
+ "bellpepper-core",
+ "bincode",
+ "blake2s_simd",
+ "byteorder",
+ "crossbeam-channel",
+ "digest 0.10.7",
+ "ec-gpu",
+ "ec-gpu-gen",
  "ff",
  "group",
+ "log",
+ "memmap2 0.5.10",
+ "nam-blstrs",
+ "pairing",
+ "rand",
+ "rand_core",
+ "rayon",
+ "rustversion",
+ "serde",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "nam-blst"
+version = "0.3.15-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1632631c6e2ff973612128336180d9002de7137df421633e7c4d7e8a2d6c3d"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "nam-blstrs"
+version = "0.7.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b31595611bdfcbe0880c411d325e6aae7bade26fcdc5dc4cc8aeec54a7db06"
+dependencies = [
+ "byte-slice-cast",
+ "ff",
+ "group",
+ "nam-blst",
  "pairing",
  "rand_core",
+ "serde",
  "subtle",
 ]
 
@@ -4335,14 +4482,14 @@ dependencies = [
 
 [[package]]
 name = "nam-jubjub"
-version = "0.10.1-nam.0"
+version = "1.10.1-nam.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdced0f5975d8f80cb82a84d464481acb7b586d22f447dda86947d6a572997b9"
+checksum = "7a23e14862160638c432432025599689ccd1e28c05428d8a437986240c0b89f2"
 dependencies = [
  "bitvec",
  "ff",
  "group",
- "nam-bls12_381",
+ "nam-blstrs",
  "rand_core",
  "subtle",
 ]
@@ -4767,7 +4914,7 @@ dependencies = [
  "async-trait",
  "borsh",
  "eyre",
- "flume",
+ "flume 0.11.1",
  "futures",
  "itertools 0.14.0",
  "lazy_static",
@@ -6555,7 +6702,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "serdect",
  "subtle",
@@ -7483,6 +7630,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -9050,6 +9206,16 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yastl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca6c5a4d66c1a9ea261811cf4773c27343de7e5033e1b75ea3f297dc7db3c1a"
+dependencies = [
+ "flume 0.10.14",
+ "scopeguard",
+]
 
 [[package]]
 name = "yoke"

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -282,19 +282,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
-name = "bellman"
-version = "0.14.0"
+name = "bellpepper-core"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afceed28bac7f9f5a508bca8aeeff51cdfa4770c0b967ac55c621e2ddfd6171"
+checksum = "b2c9a1b2f748c59938bc72165ebdf34efffeecee9cfbe0bb7d6b01aea21cd523"
 dependencies = [
- "bitvec",
  "blake2s_simd",
  "byteorder",
  "ff",
- "group",
- "pairing",
- "rand_core",
- "subtle",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -382,7 +388,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -391,7 +397,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -669,6 +675,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,7 +720,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core",
  "subtle",
  "zeroize",
@@ -717,7 +732,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -825,7 +840,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -898,6 +913,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
+name = "ec-gpu"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd63582de2b59ea1aa48d7c1941b5d87618d95484397521b3acdfa0e1e9f5e45"
+
+[[package]]
+name = "ec-gpu-gen"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2353854622ec1abfd22243eb958453b95f1502e2a56648bf9db49ccbfb55f01"
+dependencies = [
+ "bitvec",
+ "crossbeam-channel",
+ "ec-gpu",
+ "execute",
+ "ff",
+ "group",
+ "hex",
+ "log",
+ "num_cpus",
+ "once_cell",
+ "rayon",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+ "yastl",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,7 +1008,7 @@ dependencies = [
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "pkcs8",
  "rand_core",
@@ -1077,6 +1120,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "execute"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a82608ee96ce76aeab659e9b8d3c2b787bffd223199af88c674923d861ada10"
+dependencies = [
+ "execute-command-macro",
+ "execute-command-tokens",
+ "generic-array 1.2.0",
+]
+
+[[package]]
+name = "execute-command-macro"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dec53d547564e911dc4ff3ecb726a64cf41a6fa01a2370ebc0d95175dd08bd"
+dependencies = [
+ "execute-command-macro-impl",
+]
+
+[[package]]
+name = "execute-command-macro-impl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8cd46a041ad005ab9c71263f9a0ff5b529eac0fe4cc9b4a20f4f0765d8cf4b"
+dependencies = [
+ "execute-command-tokens",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "execute-command-tokens"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69dc321eb6be977f44674620ca3aa21703cb20ffbe560e1ae97da08401ffbcad"
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1208,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
 dependencies = [
  "paste",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -1293,6 +1382,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1414,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,7 +1427,9 @@ checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "memuse",
+ "rand",
  "rand_core",
+ "rand_xorshift",
  "subtle",
 ]
 
@@ -1373,6 +1479,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2073,11 +2185,11 @@ dependencies = [
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.3.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ad43a3f5795945459d577f6589cf62a476e92c79b75e70cd954364e14ce17b"
+checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
- "serde",
+ "either",
 ]
 
 [[package]]
@@ -2112,7 +2224,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2273,23 +2385,24 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "masp_note_encryption"
-version = "2.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ada01979db25a366c3e7382d0693fc65571dea7dc81960ef03a00aa4bb12f3"
+checksum = "0246bfddd3de5ba4c878d52ff5d62992a7059e0a7eae010ffea6edcf47929653"
 dependencies = [
  "borsh",
  "chacha20",
  "chacha20poly1305",
  "cipher",
+ "nam-blstrs",
  "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "masp_primitives"
-version = "2.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fc77ab4163be1a72719a6cd27f9ab1f86dc9080a3d42aa2edd41e687aa97d5"
+checksum = "961a3494f0cbd5ab32042b4f5ce4bdeb1dba148b79f60a1cfe15b121e59f1de5"
 dependencies = [
  "aes",
  "bip0039",
@@ -2306,7 +2419,7 @@ dependencies = [
  "lazy_static",
  "masp_note_encryption",
  "memuse",
- "nam-bls12_381",
+ "nam-blstrs",
  "nam-jubjub",
  "nam-num-traits",
  "nonempty 0.11.0",
@@ -2319,21 +2432,23 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "2.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a2bf8522c7f7a6529c7c450119e3fb06c2be638894866f3ad9e5a133a5d048"
+checksum = "68de02b0e1370b9070da23ce237a240cc35a7b5928f699aa4a49363734f7eecc"
 dependencies = [
- "bellman",
  "blake2b_simd",
  "directories",
+ "ff",
  "getrandom 0.2.15",
  "group",
  "itertools 0.14.0",
  "lazy_static",
  "masp_primitives",
- "nam-bls12_381",
+ "nam-bellperson",
+ "nam-blstrs",
  "nam-jubjub",
  "nam-redjubjub",
+ "pairing",
  "rand_core",
  "tracing",
 ]
@@ -2343,6 +2458,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memuse"
@@ -2369,15 +2493,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
-name = "nam-bls12_381"
-version = "0.8.1-nam.0"
+name = "nam-bellperson"
+version = "0.26.2-nam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e768b0e2383163f2f4bbce1112d6454b2cb515950b0a9177733f0d71254d2c68"
+checksum = "130c55b8c2814e06aeb0d919e2aaaf8c7ef0a80cd6bdeca2d5d680e1cc382258"
 dependencies = [
+ "bellpepper-core",
+ "bincode",
+ "blake2s_simd",
+ "byteorder",
+ "crossbeam-channel",
+ "digest 0.10.7",
+ "ec-gpu",
+ "ec-gpu-gen",
  "ff",
  "group",
+ "log",
+ "memmap2",
+ "nam-blstrs",
+ "pairing",
+ "rand",
+ "rand_core",
+ "rayon",
+ "rustversion",
+ "serde",
+ "sha2 0.10.8",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "nam-blst"
+version = "0.3.15-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1632631c6e2ff973612128336180d9002de7137df421633e7c4d7e8a2d6c3d"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "nam-blstrs"
+version = "0.7.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b31595611bdfcbe0880c411d325e6aae7bade26fcdc5dc4cc8aeec54a7db06"
+dependencies = [
+ "byte-slice-cast",
+ "ff",
+ "group",
+ "nam-blst",
  "pairing",
  "rand_core",
+ "serde",
  "subtle",
 ]
 
@@ -2395,14 +2563,14 @@ dependencies = [
 
 [[package]]
 name = "nam-jubjub"
-version = "0.10.1-nam.0"
+version = "1.10.1-nam.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdced0f5975d8f80cb82a84d464481acb7b586d22f447dda86947d6a572997b9"
+checksum = "7a23e14862160638c432432025599689ccd1e28c05428d8a437986240c0b89f2"
 dependencies = [
  "bitvec",
  "ff",
  "group",
- "nam-bls12_381",
+ "nam-blstrs",
  "rand_core",
  "subtle",
 ]
@@ -3010,6 +3178,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,6 +3554,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,7 +3825,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "serdect",
  "subtle",
@@ -4067,6 +4254,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -4788,6 +4984,16 @@ dependencies = [
  "libm",
  "rand",
  "serde",
+]
+
+[[package]]
+name = "yastl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca6c5a4d66c1a9ea261811cf4773c27343de7e5033e1b75ea3f297dc7db3c1a"
+dependencies = [
+ "flume",
+ "scopeguard",
 ]
 
 [[package]]


### PR DESCRIPTION
## Describe your changes
The masp now uses the bellperson backend to synthesize circuits and build zk proofs. Benchmarking this indicates substantial speed ups in proving time.
