### PR TITLE
tests: reduce the number of test cases for slower proptests

### DIFF
--- a/crates/proof_of_stake/src/rewards.rs
+++ b/crates/proof_of_stake/src/rewards.rs
@@ -1072,6 +1072,7 @@ mod claim_optimizations {
     use namada_state::testing::TestState;
     use prop::collection;
     use proptest::prelude::*;
+    use proptest::test_runner::Config;
     use storage::{
         bond_handle, delegator_redelegated_bonds_handle,
         validator_slashes_handle,
@@ -1084,6 +1085,10 @@ mod claim_optimizations {
     use crate::{FoldRedelegatedBondsResult, GenesisValidator, OwnedPosParams};
 
     proptest! {
+        #![proptest_config(Config {
+            cases: 10,
+            .. Config::default()
+        })]
         #[test]
         fn test_optimized_computer_current_rewards(
             input in arb_test_optimized_computer_current_rewards()

--- a/crates/proof_of_stake/src/tests/test_pos.rs
+++ b/crates/proof_of_stake/src/tests/test_pos.rs
@@ -65,7 +65,7 @@ use crate::{
 proptest! {
     // Generate arb valid input for `test_test_init_genesis_aux`
     #![proptest_config(Config {
-        cases: 100,
+        cases: 10,
         .. Config::default()
     })]
     #[test]
@@ -82,7 +82,7 @@ proptest! {
 proptest! {
     // Generate arb valid input for `test_bonds_aux`
     #![proptest_config(Config {
-        cases: 100,
+        cases: 10,
         .. Config::default()
     })]
     #[test]
@@ -98,7 +98,7 @@ proptest! {
 proptest! {
     // Generate arb valid input for `test_unjail_validator_aux`
     #![proptest_config(Config {
-        cases: 100,
+        cases: 10,
         .. Config::default()
     })]
     #[test]
@@ -177,7 +177,7 @@ proptest! {
 proptest! {
     // Generate arb valid input for `test_is_delegator`
     #![proptest_config(Config {
-        cases: 100,
+        cases: 10,
         .. Config::default()
     })]
     #[test]
@@ -193,6 +193,7 @@ proptest! {
 proptest! {
     // Generate arb valid input for `test_jail_for_liveness_aux`
     #![proptest_config(Config {
+        cases: 10,
         .. Config::default()
     })]
     #[test]

--- a/crates/proof_of_stake/src/tests/test_slash_and_redel.rs
+++ b/crates/proof_of_stake/src/tests/test_slash_and_redel.rs
@@ -50,7 +50,7 @@ use crate::{
 proptest! {
     // Generate arb valid input for `test_simple_redelegation_aux`
     #![proptest_config(Config {
-        cases: 100,
+        cases: 10,
         .. Config::default()
     })]
     #[test]
@@ -319,7 +319,7 @@ fn test_simple_redelegation_aux(
 proptest! {
     // Generate arb valid input for `test_slashes_with_unbonding_aux`
     #![proptest_config(Config {
-        cases: 100,
+        cases: 10,
         .. Config::default()
     })]
     #[test]
@@ -505,7 +505,7 @@ fn test_slashes_with_unbonding_aux(
 proptest! {
     // Generate arb valid input for `test_simple_redelegation_aux`
     #![proptest_config(Config {
-        cases: 100,
+        cases: 10,
         .. Config::default()
     })]
     #[test]
@@ -773,7 +773,7 @@ fn test_redelegation_with_slashing_aux(
 proptest! {
     // Generate arb valid input for `test_chain_redelegations_aux`
     #![proptest_config(Config {
-        cases: 100,
+        cases: 10,
         .. Config::default()
     })]
     #[test]

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -2175,6 +2175,7 @@ mod test_shielded_wallet {
     use namada_core::token::MaspDigitPos;
     use namada_io::NamadaIo;
     use proptest::proptest;
+    use proptest::test_runner::Config;
     use tempfile::tempdir;
 
     use super::*;
@@ -2525,6 +2526,10 @@ mod test_shielded_wallet {
     }
 
     proptest! {
+        #![proptest_config(Config {
+            cases: 10,
+            .. Config::default()
+        })]
         /// In this test, we have a single incentivized token
         /// shielded at MaspEpoch(2), owned by the shielded wallet.
         /// The amount of owned token is the parameter `principal`.


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
