### PR TITLE
Update masp to `v3.0.8`

### DIFF
--- a/.changelog/unreleased/bug-fixes/4878-update-to-masp-v3.0.6.md
+++ b/.changelog/unreleased/bug-fixes/4878-update-to-masp-v3.0.6.md
@@ -1,0 +1,5 @@
+- Integrate an updated `nam-bellperson` that fixes issues in wasm,
+  namely the usage of `std::time::Instant`, which has been replaced
+  with `wasmtimer::std::Instant`. Moreover, silence a lot of the
+  `INFO` log lines previously sent to the CLI, when generating proofs.
+  ([\#4878](https://github.com/namada-net/namada/pull/4878))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5165,9 +5165,9 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "3.0.5"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0246bfddd3de5ba4c878d52ff5d62992a7059e0a7eae010ffea6edcf47929653"
+checksum = "f49ba53e70593fba96ef5eba4b30fb954ce80beea15f158fb661780f1dc76bb4"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -5181,9 +5181,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "3.0.5"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961a3494f0cbd5ab32042b4f5ce4bdeb1dba148b79f60a1cfe15b121e59f1de5"
+checksum = "3011930a4f7857e360349ef8eea3f255e128af7b18c448ad9b9f6e4caa32703d"
 dependencies = [
  "aes",
  "arbitrary",
@@ -5215,9 +5215,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "3.0.5"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68de02b0e1370b9070da23ce237a240cc35a7b5928f699aa4a49363734f7eecc"
+checksum = "012f92bc64f5a2dc7587b3917d135de44dad1d2bbb2a0c2e0cc380eb79d0e094"
 dependencies = [
  "blake2b_simd",
  "directories 5.0.1",
@@ -5406,9 +5406,9 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "nam-bellperson"
-version = "0.26.2-nam.2"
+version = "0.26.5-nam.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130c55b8c2814e06aeb0d919e2aaaf8c7ef0a80cd6bdeca2d5d680e1cc382258"
+checksum = "2518744be8c4c7899e55f22df7f96e4ed02fd90d900e6df22eb13a9b239876a3"
 dependencies = [
  "bellpepper-core",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,8 +189,8 @@ libfuzzer-sys = "0.4"
 libloading = "0.8"
 linkme = "0.3"
 madato = "0.7"
-masp_primitives = "3.0.5"
-masp_proofs = { version = "3.0.5", default-features = false, features = ["local-prover"] }
+masp_primitives = "3.0.8"
+masp_proofs = { version = "3.0.8", default-features = false, features = ["local-prover"] }
 num256 = "0.6"
 num_cpus = "1.13"
 num_enum = "0.7"

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -4220,9 +4220,9 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "3.0.5"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0246bfddd3de5ba4c878d52ff5d62992a7059e0a7eae010ffea6edcf47929653"
+checksum = "f49ba53e70593fba96ef5eba4b30fb954ce80beea15f158fb661780f1dc76bb4"
 dependencies = [
  "borsh",
  "chacha20",
@@ -4235,9 +4235,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "3.0.5"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961a3494f0cbd5ab32042b4f5ce4bdeb1dba148b79f60a1cfe15b121e59f1de5"
+checksum = "3011930a4f7857e360349ef8eea3f255e128af7b18c448ad9b9f6e4caa32703d"
 dependencies = [
  "aes",
  "bip0039",
@@ -4268,9 +4268,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "3.0.5"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68de02b0e1370b9070da23ce237a240cc35a7b5928f699aa4a49363734f7eecc"
+checksum = "012f92bc64f5a2dc7587b3917d135de44dad1d2bbb2a0c2e0cc380eb79d0e094"
 dependencies = [
  "blake2b_simd",
  "directories",
@@ -4413,9 +4413,9 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "nam-bellperson"
-version = "0.26.2-nam.2"
+version = "0.26.5-nam.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130c55b8c2814e06aeb0d919e2aaaf8c7ef0a80cd6bdeca2d5d680e1cc382258"
+checksum = "2518744be8c4c7899e55f22df7f96e4ed02fd90d900e6df22eb13a9b239876a3"
 dependencies = [
  "bellpepper-core",
  "bincode",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2400,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "3.0.5"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961a3494f0cbd5ab32042b4f5ce4bdeb1dba148b79f60a1cfe15b121e59f1de5"
+checksum = "3011930a4f7857e360349ef8eea3f255e128af7b18c448ad9b9f6e4caa32703d"
 dependencies = [
  "aes",
  "bip0039",
@@ -2432,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "3.0.5"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68de02b0e1370b9070da23ce237a240cc35a7b5928f699aa4a49363734f7eecc"
+checksum = "012f92bc64f5a2dc7587b3917d135de44dad1d2bbb2a0c2e0cc380eb79d0e094"
 dependencies = [
  "blake2b_simd",
  "directories",
@@ -2494,9 +2494,9 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "nam-bellperson"
-version = "0.26.2-nam.2"
+version = "0.26.5-nam.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130c55b8c2814e06aeb0d919e2aaaf8c7ef0a80cd6bdeca2d5d680e1cc382258"
+checksum = "2518744be8c4c7899e55f22df7f96e4ed02fd90d900e6df22eb13a9b239876a3"
 dependencies = [
  "bellpepper-core",
  "bincode",


### PR DESCRIPTION
## Describe your changes

https://crates.io/crates/masp_proofs/3.0.6

This version integrates an updated `nam-bellperson` that fixes issues in wasm, namely the usage of `std::time::Instant`, which has been replaced with `wasmtimer::std::Instant`. It also silences a lot of the `INFO` logs previously sent to the CLI, when generating proofs.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
