### PR TITLE
ci: bind workflow_dispatch release tag via env before shell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
         git fetch --tags --force origin # WA: https://github.com/actions/checkout/issues/882
     - name: Switch to tag if specified
       if: "${{ github.event.inputs.tag != '' }}"
-      run: git checkout ${{ github.event.inputs.tag }}
+      env:
+        RELEASE_TAG: ${{ github.event.inputs.tag }}
+      run: git checkout "$RELEASE_TAG"
     - name: Build wasm
       run: make build-wasm-scripts
     - name: Upload wasm artifacts 
@@ -67,7 +69,9 @@ jobs:
           git fetch --tags --force origin # WA: https://github.com/actions/checkout/issues/882
       - name: Switch to tag if specified
         if: "${{ github.event.inputs.tag != '' }}"
-        run: git checkout ${{ github.event.inputs.tag }}
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag }}
+        run: git checkout "$RELEASE_TAG"
       - name: Install dependencies
         if: startsWith(runner.os, 'Linux')
         run: sudo apt-get update && sudo apt-get -y install libudev-dev


### PR DESCRIPTION
## Summary
- Bind `github.event.inputs.tag` through `env: RELEASE_TAG` before `git checkout` in both wasm and release-binaries jobs.
- Same class as GitHub’s documented script-injection guidance for interpolating `workflow_dispatch` inputs into `run:` scripts.

## Test plan
- [ ] Manual dispatch with a tag still checks out that tag in both jobs
- [ ] Tag-push releases (no dispatch input) unchanged


Made with [Cursor](https://cursor.com)